### PR TITLE
Change order of checks to skip version check for Amazon linux

### DIFF
--- a/tasks/pam.yml
+++ b/tasks/pam.yml
@@ -71,14 +71,14 @@
   yum:
     name: '{{ os_packages_pam_cracklib }}'
     state: 'absent'
-  when: (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version|int is version('7', '<') and not ansible_facts.distribution == 'Amazon')
+  when: (not ansible_facts.distribution == 'Amazon' and ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version|int is version('7', '<'))
         and os_auth_pam_passwdqc_enable
 
 - name: install the package for strong password checking
   yum:
     name: '{{ os_packages_pam_passwdqc }}'
     state: 'present'
-  when: (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version|int is version('7', '<') and not ansible_facts.distribution == 'Amazon')
+  when: (not ansible_facts.distribution == 'Amazon' and ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version|int is version('7', '<'))
         and os_auth_pam_passwdqc_enable
 
 - name: remove passwdqc


### PR DESCRIPTION
This fixes https://github.com/dev-sec/ansible-os-hardening/issues/244.