### PR TITLE
add restart-auditd handler 

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,6 @@
   command: 'update-initramfs -u'
 
 - name: restart-auditd
-  service:
-    name: auditd
-    state: restarted
-    use: service
+  command:
+    cmd: 'service auditd restart' # rhel: see: https://access.redhat.com/solutions/2664811
+    warn: no # sadly 'service' module fails in that case also by using 'use: service'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: update-initramfs
   command: 'update-initramfs -u'
+
+- name: restart-auditd
+  command:
+    cmd: 'service auditd restart' # rhel: see: https://access.redhat.com/solutions/2664811
+    warn: no # sadly 'service' module fails in that case also by using 'use: service'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,7 @@
   command: 'update-initramfs -u'
 
 - name: restart-auditd
-  command:
-    cmd: 'service auditd restart' # rhel: see: https://access.redhat.com/solutions/2664811
-    warn: no # sadly 'service' module fails in that case also by using 'use: service'
+  service:
+    name: auditd
+    state: restarted
+    use: service

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -4,6 +4,7 @@
   package:
     name: '{{ auditd_package }}'
     state: 'present'
+  tags: auditd
 
 - name: configure auditd | package-08
   template:
@@ -12,3 +13,5 @@
     owner: 'root'
     group: 'root'
     mode: '0640'
+  notify: 'restart-auditd'
+  tags: auditd

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -14,4 +14,3 @@
     group: 'root'
     mode: '0640'
   notify: 'restart-auditd'
-  tags: auditd

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -4,7 +4,6 @@
   package:
     name: '{{ auditd_package }}'
     state: 'present'
-  tags: auditd
 
 - name: configure auditd | package-08
   template:
@@ -14,4 +13,3 @@
     group: 'root'
     mode: '0640'
   notify: 'restart-auditd'
-  tags: auditd

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -14,3 +14,4 @@
     group: 'root'
     mode: '0640'
   notify: 'restart-auditd'
+  tags: auditd


### PR DESCRIPTION
add restart-auditd handler as after configuration change (e.g. of os_auditd_max_log_file_action) you need to restart. 
Sadly on rhel7 systems you cannot use systemd. And as debian derivates use service as alias and it works I kept it that simple but ugly. 
Also adding 'auditd'-tag to make it easy only run that config change if needed.