### PR TITLE
fix changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate changelog
-        uses: charmixer/auto-changelog-action@8095796
+        uses: charmixer/auto-changelog-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           future_release: ${{ steps.version.outputs.next-version }}
+          # this excludes all versions prior to the collection-release
+          # since they break the changelog generation with the error:
+          # "No common ancestor between ... and $version"
+          exclude_tags_regex: "[0-6]\.\d\.\d"
 
       - name: push changelog
         uses: github-actions-x/commit@v2.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           # this excludes all versions prior to the collection-release
           # since they break the changelog generation with the error:
           # "No common ancestor between ... and $version"
-          exclude_tags_regex: "[0-6]\.\d\.\d"
+          exclude_tags_regex: '[0-6]\.\d\.\d'
 
       - name: push changelog
         uses: github-actions-x/commit@v2.6

--- a/OS_HARDENING_CHANGELOG.md
+++ b/OS_HARDENING_CHANGELOG.md
@@ -1,37 +1,5 @@
 # Changelog
 
-## [7.0.0](https://github.com/dev-sec/ansible-os-hardening/tree/7.0.0) (2020-11-11)
-
-[Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/6.2.0...7.0.0)
-
-**Breaking changes:**
-
-- Move all roles to one single collection [\#332](https://github.com/dev-sec/ansible-os-hardening/pull/332) [[breaking](https://github.com/dev-sec/ansible-os-hardening/labels/breaking)] ([rndmh3ro](https://github.com/rndmh3ro))
-
-**Implemented enhancements:**
-
-- Breaking change in ansible-lint - set file permissions explicitly [\#299](https://github.com/dev-sec/ansible-os-hardening/issues/299) [[enhancement](https://github.com/dev-sec/ansible-os-hardening/labels/enhancement)] [[minor](https://github.com/dev-sec/ansible-os-hardening/labels/minor)] [[os_hardening](https://github.com/dev-sec/ansible-os-hardening/labels/os_hardening)]
-- Improve Documentation [\#315](https://github.com/dev-sec/ansible-os-hardening/pull/315) [[enhancement](https://github.com/dev-sec/ansible-os-hardening/labels/enhancement)] [[os_hardening](https://github.com/dev-sec/ansible-os-hardening/labels/os_hardening)] ([schurzi](https://github.com/schurzi))
-- Arch support [\#303](https://github.com/dev-sec/ansible-os-hardening/pull/303) [[enhancement](https://github.com/dev-sec/ansible-os-hardening/labels/enhancement)] [[minor](https://github.com/dev-sec/ansible-os-hardening/labels/minor)] [[os_hardening](https://github.com/dev-sec/ansible-os-hardening/labels/os_hardening)] ([rndmh3ro](https://github.com/rndmh3ro))
-- fix linting for molecule [\#301](https://github.com/dev-sec/ansible-os-hardening/pull/301) [[enhancement](https://github.com/dev-sec/ansible-os-hardening/labels/enhancement)] [[os_hardening](https://github.com/dev-sec/ansible-os-hardening/labels/os_hardening)] [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)] ([schurzi](https://github.com/schurzi))
-- file permissions explicitly defined [\#300](https://github.com/dev-sec/ansible-os-hardening/pull/300) [[enhancement](https://github.com/dev-sec/ansible-os-hardening/labels/enhancement)] [[minor](https://github.com/dev-sec/ansible-os-hardening/labels/minor)] [[os_hardening](https://github.com/dev-sec/ansible-os-hardening/labels/os_hardening)] ([danielkubat](https://github.com/danielkubat))
-
-**Fixed bugs:**
-
-- Task "set 10.hardcore.conf perms to 0400 and root ownership" fails in check mode [\#313](https://github.com/dev-sec/ansible-os-hardening/issues/313) [[bug](https://github.com/dev-sec/ansible-os-hardening/labels/bug)] [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)]
-- use touch for 10.hardcore.conf to avoid problems with dry-run [\#314](https://github.com/dev-sec/ansible-os-hardening/pull/314) [[bug](https://github.com/dev-sec/ansible-os-hardening/labels/bug)] [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)] ([schurzi](https://github.com/schurzi))
-- use touch with no date changes [\#310](https://github.com/dev-sec/ansible-os-hardening/pull/310) [[bug](https://github.com/dev-sec/ansible-os-hardening/labels/bug)] [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)] ([rndmh3ro](https://github.com/rndmh3ro))
-- do not touch sysctl file to avoid idempotency problems [\#309](https://github.com/dev-sec/ansible-os-hardening/pull/309) [[bug](https://github.com/dev-sec/ansible-os-hardening/labels/bug)] [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)] ([rndmh3ro](https://github.com/rndmh3ro))
-
-**Closed issues:**
-
-- Any planned support for RHEL/CentOS 8? [\#298](https://github.com/dev-sec/ansible-os-hardening/issues/298)
-
-**Merged pull requests:**
-
-- prettier markdown files action added [\#322](https://github.com/dev-sec/ansible-os-hardening/pull/322) ([danielkubat](https://github.com/danielkubat))
-- adjust permissions on shadow file on suse [\#311](https://github.com/dev-sec/ansible-os-hardening/pull/311) [[patch](https://github.com/dev-sec/ansible-os-hardening/labels/patch)] ([rndmh3ro](https://github.com/rndmh3ro))
-
 ## [6.2.0](https://github.com/dev-sec/ansible-os-hardening/tree/6.2.0) (2020-08-17)
 
 [Full Changelog](https://github.com/dev-sec/ansible-os-hardening/compare/6.1.0...6.2.0)


### PR DESCRIPTION
the changelog generation fails because we merged other repos into
this one and these commits do not share a common ancestor.
see this issue: https://github.com/github-changelog-generator/github-changelog-generator/issues/665

to workaround this, we change the changelog generation so all tags older than 7.0.0 will be ignored
(--since-tag does not work here because it still works on all tags). This however will remove
 older releases from the changelog so we move these old releases into a separate file.
this is okay for me since these old releases are for ansible-os-hardening  and not the collection.
the new changelog file will contain all changes since 7.0.0.

this pr is waiting for https://github.com/CharMixer/auto-changelog-action/pull/14

Signed-off-by: Sebastian Gumprich <sebastian.gumprich@t-systems.com>