### PR TITLE
`ssh_print_motd` replaced by `ssh_print_pam_motd`

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -104,9 +104,6 @@ Warning: This role disables root-login on the target server! Please make sure yo
 - `ssh_authorized_principals`
   - Default: `[]`
   - Description: list of hashes containing file paths and authorized principals, see `default_custom.yml` for all options. Only used if `ssh_authorized_principals_file` is set.
-- `ssh_print_motd`
-  - Default: `false`
-  - Description: false to disable printing of the MOTD
 - `ssh_print_pam_motd`
   - Default: `false`
   - Description: false to disable printing of the MOTD via pam (Debian and Ubuntu)


### PR DESCRIPTION
This may be a leftover in README.md from a previous change of the ssh_hardening role.

I assume that the line `ssh_print_motd` needs to be deleted from the readme. I think (but have not checked) this option was replaced by `ssh_print_pam_motd`.

I assume this because it appears that's the only 'motd' variable used in the hardening task:

https://github.com/dev-sec/ansible-collection-hardening/blob/83e29b01f529be07a18f5223427258e986cb6e2b/roles/ssh_hardening/tasks/hardening.yml#L57