### PR TITLE
Reordering stuff to alphabetical order + SYN Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ansible Collection - devsec.hardening
 
 ![devsec.os_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.os_hardening/badge.svg)
-![devsec.ssh_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.ssh_hardening/badge.svg)
-![devsec.nginx_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.nginx_hardening/badge.svg)
 ![devsec.mysql_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.mysql_hardening/badge.svg)
+![devsec.nginx_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.nginx_hardening/badge.svg)
+![devsec.ssh_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.ssh_hardening/badge.svg)
 
 ## Description
 
@@ -11,24 +11,24 @@ This collection provides battle tested hardening for:
 
 - Linux operating systems:
   - CentOS 7/8
-  - Ubuntu 16.04/18.04/20.04
   - Debian 9/10
-  - Arch Linux (some roles supported)
-  - Suse Tumbleweed (some roles supported)
-  - Fedora (some roles supported)
+  - Ubuntu 16.04/18.04/20.04
   - Amazon Linux (some roles supported)
-- OpenSSH 5.3 and later
-- Nginx 1.0.16 or later
+  - Arch Linux (some roles supported)
+  - Fedora (some roles supported)
+  - Suse Tumbleweed (some roles supported)
 - MySQL
   - MySQL >= 5.7.31, >= 8.0.3
   - MariaDB >= 5.5.65, >= 10.1.45, >= 10.3.17
+- Nginx 1.0.16 or later
+- OpenSSH 5.3 and later
 
 The hardening is intended to be compliant with the Inspec DevSec Baselines:
 
 - https://github.com/dev-sec/linux-baseline
-- https://github.com/dev-sec/ssh-baseline
-- https://github.com/dev-sec/nginx-baseline
 - https://github.com/dev-sec/mysql-baseline
+- https://github.com/dev-sec/nginx-baseline
+- https://github.com/dev-sec/ssh-baseline
 
 ## Looking for the old ansible-os-hardening role?
 
@@ -41,9 +41,9 @@ This role is now part of the hardening-collection. You can find the old role in 
 ## Included content
 
 - [os_hardening](roles/os_hardening/)
-- [ssh_hardening](roles/ssh_hardening/)
 - [mysql_hardening](roles/mysql_hardening/)
 - [nginx_hardening](roles/nginx_hardening/)
+- [ssh_hardening](roles/ssh_hardening/)
 
 In progress, not working:
 

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -171,6 +171,14 @@ sysctl_config:
   # RFC 1337 fix F1 | sysctl-10
   net.ipv4.tcp_rfc1337: 1
 
+  # Attackers use SYN flood attacks to perform a denial of service attack on a system
+  # by sending many SYN packets without completing the three way handshake.
+  # This will quickly use up slots in the kernel's half-open connection queue and
+  # prevent legitimate connections from succeeding.
+  # SYN cookies allow the system to keep accepting valid connections, even if
+  # under a denial of service attack. CIS Distro Independent 3.2.8.
+  net.ipv4.tcp_syncookies: 1
+
   # Send(router) or accept(host) RFC1620 shared media redirects | sysctl-12
   net.ipv4.conf.all.shared_media: 1
   net.ipv4.conf.default.shared_media: 1

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -53,99 +53,42 @@ ufw_manage_builtins: 'no'
 ufw_ipt_modules: 'nf_conntrack_ftp nf_nat_ftp nf_conntrack_netbios_ns'
 
 sysctl_config:
-  # Disable IPv4 traffic forwarding. | sysctl-01
-  net.ipv4.ip_forward: 0
+  # These settings eliminate an entire class of security vulnerabilities:
+  # time-of-check-time-of-use cross-privilege attacks using guessable
+  # filenames (generally seen as "/tmp file race" vulnerabilities).
+  fs.protected_hardlinks: 1
+  fs.protected_symlinks: 1
 
-  # Disable IPv6 traffic forwarding. | sysctl-19
-  net.ipv6.conf.all.forwarding: 0
+  # Prevent core dumps with SUID. These are usually only
+  # needed by developers and may contain sensitive information. | sysctl-31
+  fs.suid_dumpable: 0
 
-  # ignore RAs on Ipv6. | sysctl-25
-  net.ipv6.conf.all.accept_ra: 0
-  net.ipv6.conf.default.accept_ra: 0
+  # Controls whether core dumps will append the PID to the core filename
+  # Useful for debugging multi-threaded applications
+  kernel.core_uses_pid: 1
 
-  # Enable RFC-recommended source validation feature. | sysctl-02
-  net.ipv4.conf.all.rp_filter: 1
-  net.ipv4.conf.default.rp_filter: 1
+  # When an attacker is trying to exploit the local kernel, it is often
+  # helpful to be able to examine where in memory the kernel, modules,
+  # and data structures live. As such, kernel addresses should be treated
+  # as sensitive information.
+  #
+  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
+  # /proc/modules, etc), and this setting can censor the addresses. A value
+  # of "0" allows all users to see the kernel addresses. A value of "1"
+  # limits visibility to the root user, and "2" blocks even the root user.
+  #
+  # Some off-the-shelf malware exploit kernel addresses exposed
+  # via /proc/kallsyms so by not making these addresses easily available
+  # we increase the cost of such attack some what; now such malware has
+  # to check which kernel Tails is running and then fetch the corresponding
+  # kernel address map from some external source. This is not hard,
+  # but certainly not all malware has such functionality. | Tails-2
+  kernel.kptr_restrict: 2
 
-  # Reduce the surface on SMURF attacks. | sysctl-04
-  # Make sure to ignore ECHO broadcasts, which are only required in broad network analysis.
-  net.ipv4.icmp_echo_ignore_broadcasts: 1
+  # kexec is dangerous: it enables replacement of the running kernel. | Tails-3
+  kernel.kexec_load_disabled: 1
 
-  # There is no reason to accept bogus error responses from ICMP, so ignore them instead. | sysctl-03
-  net.ipv4.icmp_ignore_bogus_error_responses: 1
-
-  # Limit the amount of traffic the system uses for ICMP. | sysctl-05
-  net.ipv4.icmp_ratelimit: 100
-
-  # Adjust the ICMP ratelimit to include ping, dst unreachable,
-  # source quench, ime exceed, param problem, timestamp reply, information reply | sysctl-06
-  net.ipv4.icmp_ratemask: 88089
-
-  # Disable IPv6 | sysctl-18
-  net.ipv6.conf.all.disable_ipv6: 1
-
-  # Protect against wrapping sequence numbers at gigabit speeds | sysctl-07
-  net.ipv4.tcp_timestamps: 0
-
-  # Define restriction level for announcing the local source IP | sysctl-08
-  net.ipv4.conf.all.arp_ignore: 1
-
-  # Define mode for sending replies in response to
-  # received ARP requests that resolve local target IP addresses | sysctl-09
-  net.ipv4.conf.all.arp_announce: 2
-
-  # RFC 1337 fix F1 | sysctl-10
-  net.ipv4.tcp_rfc1337: 1
-
-  # Send(router) or accept(host) RFC1620 shared media redirects | sysctl-12
-  net.ipv4.conf.all.shared_media: 1
-  net.ipv4.conf.default.shared_media: 1
-
-  # Accepting source route can lead to malicious networking behavior,
-  # so disable it if not needed. | sysctl-13
-  net.ipv4.conf.all.accept_source_route: 0
-  net.ipv4.conf.default.accept_source_route: 0
-
-  # Accepting redirects can lead to malicious networking behavior, so disable
-  # it if not needed. | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
-  net.ipv4.conf.default.accept_redirects: 0
-  net.ipv4.conf.all.accept_redirects: 0
-  net.ipv4.conf.all.secure_redirects: 0
-  net.ipv4.conf.default.secure_redirects: 0
-  net.ipv6.conf.default.accept_redirects: 0
-  net.ipv6.conf.all.accept_redirects: 0
-
-  # For non-routers: don't send redirects, these settings are 0 | sysctl-16
-  net.ipv4.conf.all.send_redirects: 0
-  net.ipv4.conf.default.send_redirects: 0
-
-  # log martian packets | sysctl-17
-  net.ipv4.conf.all.log_martians: 1
-  net.ipv4.conf.default.log_martians: 1
-
-  # ipv6 config
-  # Disable acceptance of IPv6 router solicitations messages | sysctl-21
-  net.ipv6.conf.default.router_solicitations: 0
-
-  # Disable Accept Router Preference from router advertisement | sysctl-22
-  net.ipv6.conf.default.accept_ra_rtr_pref: 0
-
-  # Disable learning Prefix Information from router advertisement | sysctl-23
-  net.ipv6.conf.default.accept_ra_pinfo: 0
-
-  # Disable learning Hop limit from router advertisement | sysctl-24
-  net.ipv6.conf.default.accept_ra_defrtr: 0
-
-  # Disable IPv6 autoconfiguration | sysctl-26
-  net.ipv6.conf.default.autoconf: 0
-
-  # Disable neighbor solicitations to send out per address | sysctl-27
-  net.ipv6.conf.default.dad_transmits: 0
-
-  # Assign one global unicast IPv6 addresses to each interface | sysctl-28
-  net.ipv6.conf.default.max_addresses: 1
-
-  # This settings controls how the kernel behaves towards module changes at
+  # This setting controls how the kernel behaves towards module changes at
   # runtime. Setting to 1 will disable module loading at runtime.
   # Setting it to 0 is actually never supported. | sysctl-29
   # kernel.modules_disabled: 1
@@ -167,14 +110,8 @@ sysctl_config:
   # * **256** - nicing of all RT tasks
   kernel.sysrq: 0
 
-  # Prevent core dumps with SUID. These are usually only
-  # needed by developers and may contain sensitive information. | sysctl-31
-  fs.suid_dumpable: 0
-
   # Virtual memory regions protection | sysctl-32
   kernel.randomize_va_space: 2
-
-  kernel.core_uses_pid: 1
 
   # The PTRACE system is used for debugging.  With it, a single user process
   # can attach to any other dumpable process owned by the same user.  In the
@@ -200,6 +137,97 @@ sysctl_config:
   # kernel.yama.ptrace_scope = 1
   kernel.yama.ptrace_scope: 1
 
+  # Disable IPv4 traffic forwarding. | sysctl-01
+  net.ipv4.ip_forward: 0
+
+  # Enable RFC-recommended source validation feature. | sysctl-02
+  net.ipv4.conf.all.rp_filter: 1
+  net.ipv4.conf.default.rp_filter: 1
+
+  # Reduce the surface on SMURF attacks. | sysctl-04
+  # Make sure to ignore ECHO broadcasts, which are only required in broad network analysis.
+  net.ipv4.icmp_echo_ignore_broadcasts: 1
+
+  # There is no reason to accept bogus error responses from ICMP, so ignore them instead. | sysctl-03
+  net.ipv4.icmp_ignore_bogus_error_responses: 1
+
+  # Limit the amount of traffic the system uses for ICMP. | sysctl-05
+  net.ipv4.icmp_ratelimit: 100
+
+  # Adjust the ICMP ratelimit to include ping, dst unreachable,
+  # source quench, ime exceed, param problem, timestamp reply, information reply | sysctl-06
+  net.ipv4.icmp_ratemask: 88089
+
+  # Protect against wrapping sequence numbers at gigabit speeds | sysctl-07
+  net.ipv4.tcp_timestamps: 0
+
+  # Define restriction level for announcing the local source IP | sysctl-08
+  net.ipv4.conf.all.arp_ignore: 1
+
+  # Define mode for sending replies in response to
+  # received ARP requests that resolve local target IP addresses | sysctl-09
+  net.ipv4.conf.all.arp_announce: 2
+
+  # RFC 1337 fix F1 | sysctl-10
+  net.ipv4.tcp_rfc1337: 1
+
+  # Send(router) or accept(host) RFC1620 shared media redirects | sysctl-12
+  net.ipv4.conf.all.shared_media: 1
+  net.ipv4.conf.default.shared_media: 1
+
+  # Accepting source route can lead to malicious networking behavior,
+  # so disable it if not needed. | sysctl-13
+  net.ipv4.conf.all.accept_source_route: 0
+  net.ipv4.conf.default.accept_source_route: 0
+
+  # For non-routers: don't send redirects, these settings are 0 | sysctl-16
+  net.ipv4.conf.all.send_redirects: 0
+  net.ipv4.conf.default.send_redirects: 0
+
+  # log martian packets | sysctl-17
+  net.ipv4.conf.all.log_martians: 1
+  net.ipv4.conf.default.log_martians: 1
+
+  # Accepting redirects can lead to malicious networking behavior, so disable
+  # it if not needed. | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
+  net.ipv4.conf.default.accept_redirects: 0
+  net.ipv4.conf.all.accept_redirects: 0
+  net.ipv4.conf.all.secure_redirects: 0
+  net.ipv4.conf.default.secure_redirects: 0
+  net.ipv6.conf.default.accept_redirects: 0
+  net.ipv6.conf.all.accept_redirects: 0
+
+  # Disable IPv6 | sysctl-18
+  net.ipv6.conf.all.disable_ipv6: 1
+
+  # Disable IPv6 traffic forwarding. | sysctl-19
+  net.ipv6.conf.all.forwarding: 0
+
+  # ignore RAs on Ipv6. | sysctl-25
+  net.ipv6.conf.all.accept_ra: 0
+  net.ipv6.conf.default.accept_ra: 0
+
+  # Disable acceptance of IPv6 router solicitations messages | sysctl-21
+  net.ipv6.conf.default.router_solicitations: 0
+
+  # Disable Accept Router Preference from router advertisement | sysctl-22
+  net.ipv6.conf.default.accept_ra_rtr_pref: 0
+
+  # Disable learning Prefix Information from router advertisement | sysctl-23
+  net.ipv6.conf.default.accept_ra_pinfo: 0
+
+  # Disable learning Hop limit from router advertisement | sysctl-24
+  net.ipv6.conf.default.accept_ra_defrtr: 0
+
+  # Disable IPv6 autoconfiguration | sysctl-26
+  net.ipv6.conf.default.autoconf: 0
+
+  # Disable neighbor solicitations to send out per address | sysctl-27
+  net.ipv6.conf.default.dad_transmits: 0
+
+  # Assign one global unicast IPv6 addresses to each interface | sysctl-28
+  net.ipv6.conf.default.max_addresses: 1
+
   # Protect the zero page of memory from userspace mmap to prevent kernel
   # NULL-dereference attacks against potential future kernel security
   # vulnerabilities.  (Added in kernel 2.6.23.)
@@ -210,38 +238,11 @@ sysctl_config:
   # is reset to the secure default each time the sysctl values are loaded.
   vm.mmap_min_addr: 65536
 
-  # These settings eliminate an entire class of security vulnerability:
-  # time-of-check-time-of-use cross-privilege attacks using guessable
-  # filenames (generally seen as "/tmp file race" vulnerabilities).
-  fs.protected_hardlinks: 1
-  fs.protected_symlinks: 1
-
   # These settings are set to the maximum supported value in order to
   # improve ASLR effectiveness for mmap, at the cost of increased
   # address-space fragmentation. | Tail-1
   vm.mmap_rnd_bits: 32
   vm.mmap_rnd_compat_bits: 16
-
-  # When an attacker is trying to exploit the local kernel, it is often
-  # helpful to be able to examine where in memory the kernel, modules,
-  # and data structures live. As such, kernel addresses should be treated
-  # as sensitive information.
-  #
-  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
-  # /proc/modules, etc), and this setting can censor the addresses. A value
-  # of "0" allows all users to see the kernel addresses. A value of "1"
-  # limits visibility to the root user, and "2" blocks even the root user.
-  #
-  # Some off-the-shelf malware exploit kernel addresses exposed
-  # via /proc/kallsyms so by not making these addresses easily available
-  # we increase the cost of such attack some what; now such malware has
-  # to check which kernel Tails is running and then fetch the corresponding
-  # kernel address map from some external source. This is not hard,
-  # but certainly not all malware has such functionality. | Tails-2
-  kernel.kptr_restrict: 2
-
-  # kexec is dangerous: it enables replacement of the running kernel. | Tails-3
-  kernel.kexec_load_disabled: 1
 
 # Do not delete the following line or otherwise the playbook will fail
 # at task 'create a combined sysctl-dict if overwrites are defined'

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -177,12 +177,11 @@ AuthorizedPrincipalsFile {{ ssh_authorized_principals_file }}
 # Network
 # -------
 
-# Disable TCP keep alive since it is spoofable. Use ClientAlive messages instead, they use the encrypted channel
+# Disable TCP keep alive since it is spoofable. Use ClientAlive messages instead, which use the encrypted channel
 TCPKeepAlive no
 
-# Manage `ClientAlive..` signals via interval and maximum count.
-# This will periodically check up to a `..CountMax` number of times within `..Interval` timeframe,
-# and abort the connection once these fail.
+# Set the SSH session idle timout.
+# The connection will automatically logout after ClientAliveInterval * ClientAliveCountMax seconds of inactivity.
 ClientAliveInterval {{ ssh_client_alive_interval }}
 ClientAliveCountMax {{ ssh_client_alive_count }}
 


### PR DESCRIPTION
Everything seems to be in random order, which makes it harder to read. I moved things around and might continue doing that if I feel like having the time doing that while I try to figure out what this role actually does.

SYN cookies is not enabled. I think it should.

CIS Benchmark: 

> 3.2.8 Ensure TCP SYN Cookies is enabled (Scored)
Profile Applicability:
 Level 1 - Server
 Level 1 - Workstation
Description:
When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
encodes the source and destination IP address and port number and the time the packet
was sent. A legitimate connection would send the ACK packet of the three way handshake
with the specially crafted sequence number. This allows the system to verify that it has
received a valid response to a SYN cookie and allow the connection, even though there is no
corresponding SYN in the queue.
Rationale:
Attackers use SYN flood attacks to perform a denial of service attacked on a system by
sending many SYN packets without completing the three way handshake. This will quickly
use up slots in the kernel's half-open connection queue and prevent legitimate connections
from succeeding. SYN cookies allow the system to keep accepting valid connections, even if
under a denial of service attack.
Audit:
Run the following commands and verify output matches:
sysctl net.ipv4.tcp_syncookies
net.ipv4.tcp_syncookies = 1
grep "net\.ipv4\.tcp_syncookies" /etc/sysctl.conf /etc/sysctl.d/*
net.ipv4.tcp_syncookies = 1