### PR TITLE
Sorted sysctl values and lists in READMEs alphabetically (No functional changes).

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ This collection provides battle tested hardening for:
 
 - Linux operating systems:
   - CentOS 7/8
-  - Ubuntu 16.04/18.04/20.04
   - Debian 9/10
-  - Arch Linux (some roles supported)
-  - Suse Tumbleweed (some roles supported)
-  - Fedora (some roles supported)
+  - Ubuntu 16.04/18.04/20.04
   - Amazon Linux (some roles supported)
-- OpenSSH 5.3 and later
-- Nginx 1.0.16 or later
+  - Arch Linux (some roles supported)
+  - Fedora (some roles supported)
+  - Suse Tumbleweed (some roles supported)
 - MySQL
-  - MySQL >= 5.7.31, >= 8.0.3
   - MariaDB >= 5.5.65, >= 10.1.45, >= 10.3.17
+  - MySQL >= 5.7.31, >= 8.0.3
+- Nginx 1.0.16 or later
+- OpenSSH 5.3 and later
 
 The hardening is intended to be compliant with the Inspec DevSec Baselines:
 
 - https://github.com/dev-sec/linux-baseline
-- https://github.com/dev-sec/ssh-baseline
-- https://github.com/dev-sec/nginx-baseline
 - https://github.com/dev-sec/mysql-baseline
+- https://github.com/dev-sec/nginx-baseline
+- https://github.com/dev-sec/ssh-baseline
 
 ## Looking for the old ansible-os-hardening role?
 
@@ -41,9 +41,9 @@ This role is now part of the hardening-collection. You can find the old role in 
 ## Included content
 
 - [os_hardening](roles/os_hardening/)
-- [ssh_hardening](roles/ssh_hardening/)
 - [mysql_hardening](roles/mysql_hardening/)
 - [nginx_hardening](roles/nginx_hardening/)
+- [ssh_hardening](roles/ssh_hardening/)
 
 In progress, not working:
 

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -93,7 +93,7 @@ We know that this is the case on Raspberry Pi.
 
 - `os_desktop_enable`
   - Default: `false`
-  - Description: true if this is a desktop system, ie Xorg, KDE/GNOME/Unity/etc
+  - Description: true if this is a desktop system, ie Xorg, KDE/GNOME/Unity/etc.
 - `os_env_extra_user_paths`
   - Default: `[]`
   - Description: add additional paths to the user's `PATH` variable (default is empty).
@@ -102,46 +102,46 @@ We know that this is the case on Raspberry Pi.
   - Description: set default permissions for new files to `750` or `700`.
 - `os_auth_pw_max_age`
   - Default: `60`
-  - Description: maximum password age (set to `99999` to effectively disable it)
+  - Description: maximum password age (set to `99999` to effectively disable it).
 - `os_auth_pw_min_age`
   - Default: `7`
-  - Description: minimum password age (before allowing any other password change)
+  - Description: minimum password age (before allowing any other password change).
 - `os_auth_retries`
   - Default: `5`
-  - Description: the maximum number of authentication attempts, before the account is locked for some time
+  - Description: the maximum number of authentication attempts, before the account is locked for some time.
 - `os_auth_lockout_time`
   - Default: `600`
-  - Description: time in seconds that needs to pass, if the account was locked due to too many failed authentication attempts
+  - Description: time in seconds that needs to pass, if the account was locked due to too many failed authentication attempts.
 - `os_auth_timeout`
   - Default: `60`
-  - Description: authentication timeout in seconds, so login will exit if this time passes
+  - Description: authentication timeout in seconds, so login will exit if this time passes.
 - `os_auth_allow_homeless`
   - Default: `false`
-  - Description: true if to allow users without home to login
+  - Description: true if to allow users without home to login.
 - `os_auth_pam_passwdqc_enable`
   - Default: `true`
-  - Description: true if you want to use strong password checking in PAM using passwdqc
+  - Description: true if you want to use strong password checking in PAM using passwdqc.
 - `os_auth_pam_passwdqc_options`
   - Default: `min=disabled,disabled,16,12,8`
-  - Description: set to any option line (as a string) that you want to pass to passwdqc
+  - Description: set to any option line (as a string) that you want to pass to passwdqc.
 - `os_security_users_allow`
   - Default: `[]`
   - Description: list of things, that a user is allowed to do. May contain `change_user`.
 - `os_security_kernel_enable_module_loading`
   - Default: `true`
-  - Description: true if you want to allowed to change kernel modules once the system is running (eg `modprobe`, `rmmod`)
+  - Description: true if you want to allowed to change kernel modules once the system is running (eg `modprobe`, `rmmod`).
 - `os_security_kernel_enable_core_dump`
   - Default: `false`
-  - Description: kernel is crashing or otherwise misbehaving and a kernel core dump is created
+  - Description: kernel is crashing or otherwise misbehaving and a kernel core dump is created.
 - `os_security_suid_sgid_enforce`
   - Default: `true`
-  - Description: true if you want to reduce SUID/SGID bits. There is already a list of items which are searched for configured, but you can also add your own
+  - Description: true if you want to reduce SUID/SGID bits. There is already a list of items which are searched for configured, but you can also add your own.
 - `os_security_suid_sgid_blacklist`
   - Default: `[]`
-  - Description: a list of paths which should have their SUID/SGID bits removed
+  - Description: a list of paths which should have their SUID/SGID bits removed.
 - `os_security_suid_sgid_whitelist`
   - Default: `[]`
-  - Description: a list of paths which should not have their SUID/SGID bits altered
+  - Description: a list of paths which should not have their SUID/SGID bits altered.
 - `os_security_suid_sgid_remove_from_unknown`
   - Default: `false`
   - Description: true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Ansible-run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
@@ -156,19 +156,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set the SELinux polixy.
 - `ufw_manage_defaults`
   - Default: `true`
-  - Description: true means apply all settings with `ufw_` prefix
+  - Description: true means apply all settings with `ufw_` prefix.
 - `ufw_ipt_sysctl`
   - Default: `''`
-  - Description: by default it disables IPT_SYSCTL in /etc/default/ufw. If you want to overwrite /etc/sysctl.conf values using ufw - set it to your sysctl dictionary, for example `/etc/ufw/sysctl.conf`
+  - Description: by default it disables IPT_SYSCTL in /etc/default/ufw. If you want to overwrite /etc/sysctl.conf values using ufw - set it to your sysctl dictionary, for example `/etc/ufw/sysctl.conf`.
 - `ufw_default_input_policy`
   - Default: `DROP`
-  - Description: set default input policy of ufw to `DROP`
+  - Description: set default input policy of ufw to `DROP`.
 - `ufw_default_output_policy`
   - Default: `ACCEPT`
-  - Description: set default output policy of ufw to `ACCEPT`
+  - Description: set default output policy of ufw to `ACCEPT`.
 - `ufw_default_forward_policy`
   - Default: `DROP`
-  - Description: set default forward policy of ufw to `DROP`
+  - Description: set default forward policy of ufw to `DROP`.
 - `os_auditd_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring auditd.

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -12,11 +12,11 @@ This role provides numerous security-related configurations, providing all-round
 
 It configures:
 
-- Remove unused yum repositories and enable GPG key-checking
-- Remove packages with known issues
+- Removes unused yum repositories and enables GPG key-checking
+- Removes packages with known issues
 - Configures pam for strong password checks
 - Installs and configures auditd
-- Disable core dumps via soft limits
+- Disables core dumps via soft limits
 - sets a restrictive umask
 - Configures execute permissions of files in system paths
 - Hardens access to shadow and passwd files
@@ -25,7 +25,7 @@ It configures:
 - Configures secure ttys
 - Configures kernel parameters via sysctl
 - Enables selinux on EL-based systems
-- Remove SUIDs and GUIDs
+- Removes SUIDs and GUIDs
 - Configures login and passwords of system accounts
 
 It will not:

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -260,10 +260,10 @@ os_unused_filesystems:
   - "vfat"
   # Obsolete network protocols that should be disabled
   # per CIS Oracle Linux 6 Benchmark (2016)
-  - "tipc"  # CIS 3.5.4
-  - "sctp"  # CIS 3.5.2
   - "dccp"  # CIS 3.5.1
   - "rds"   # CIS 3.5.3
+  - "sctp"  # CIS 3.5.2
+  - "tipc"  # CIS 3.5.4
 
 # whitelist for used filesystems
 os_filesystem_whitelist: []

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -53,99 +53,42 @@ ufw_manage_builtins: 'no'
 ufw_ipt_modules: 'nf_conntrack_ftp nf_nat_ftp nf_conntrack_netbios_ns'
 
 sysctl_config:
-  # Disable IPv4 traffic forwarding. | sysctl-01
-  net.ipv4.ip_forward: 0
+  # These settings eliminate an entire class of security vulnerabilities:
+  # time-of-check-time-of-use cross-privilege attacks using guessable
+  # filenames (generally seen as "/tmp file race" vulnerabilities).
+  fs.protected_hardlinks: 1
+  fs.protected_symlinks: 1
 
-  # Disable IPv6 traffic forwarding. | sysctl-19
-  net.ipv6.conf.all.forwarding: 0
+  # Prevent core dumps with SUID. These are usually only
+  # needed by developers and may contain sensitive information. | sysctl-31
+  fs.suid_dumpable: 0
 
-  # ignore RAs on Ipv6. | sysctl-25
-  net.ipv6.conf.all.accept_ra: 0
-  net.ipv6.conf.default.accept_ra: 0
+  # Controls whether core dumps will append the PID to the core filename
+  # Useful for debugging multi-threaded applications
+  kernel.core_uses_pid: 1
 
-  # Enable RFC-recommended source validation feature. | sysctl-02
-  net.ipv4.conf.all.rp_filter: 1
-  net.ipv4.conf.default.rp_filter: 1
+  # When an attacker is trying to exploit the local kernel, it is often
+  # helpful to be able to examine where in memory the kernel, modules,
+  # and data structures live. As such, kernel addresses should be treated
+  # as sensitive information.
+  #
+  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
+  # /proc/modules, etc), and this setting can censor the addresses. A value
+  # of "0" allows all users to see the kernel addresses. A value of "1"
+  # limits visibility to the root user, and "2" blocks even the root user.
+  #
+  # Some off-the-shelf malware exploit kernel addresses exposed
+  # via /proc/kallsyms so by not making these addresses easily available
+  # we increase the cost of such attack some what; now such malware has
+  # to check which kernel Tails is running and then fetch the corresponding
+  # kernel address map from some external source. This is not hard,
+  # but certainly not all malware has such functionality. | Tails-2
+  kernel.kptr_restrict: 2
 
-  # Reduce the surface on SMURF attacks. | sysctl-04
-  # Make sure to ignore ECHO broadcasts, which are only required in broad network analysis.
-  net.ipv4.icmp_echo_ignore_broadcasts: 1
+  # kexec is dangerous: it enables replacement of the running kernel. | Tails-3
+  kernel.kexec_load_disabled: 1
 
-  # There is no reason to accept bogus error responses from ICMP, so ignore them instead. | sysctl-03
-  net.ipv4.icmp_ignore_bogus_error_responses: 1
-
-  # Limit the amount of traffic the system uses for ICMP. | sysctl-05
-  net.ipv4.icmp_ratelimit: 100
-
-  # Adjust the ICMP ratelimit to include ping, dst unreachable,
-  # source quench, ime exceed, param problem, timestamp reply, information reply | sysctl-06
-  net.ipv4.icmp_ratemask: 88089
-
-  # Disable IPv6 | sysctl-18
-  net.ipv6.conf.all.disable_ipv6: 1
-
-  # Protect against wrapping sequence numbers at gigabit speeds | sysctl-07
-  net.ipv4.tcp_timestamps: 0
-
-  # Define restriction level for announcing the local source IP | sysctl-08
-  net.ipv4.conf.all.arp_ignore: 1
-
-  # Define mode for sending replies in response to
-  # received ARP requests that resolve local target IP addresses | sysctl-09
-  net.ipv4.conf.all.arp_announce: 2
-
-  # RFC 1337 fix F1 | sysctl-10
-  net.ipv4.tcp_rfc1337: 1
-
-  # Send(router) or accept(host) RFC1620 shared media redirects | sysctl-12
-  net.ipv4.conf.all.shared_media: 1
-  net.ipv4.conf.default.shared_media: 1
-
-  # Accepting source route can lead to malicious networking behavior,
-  # so disable it if not needed. | sysctl-13
-  net.ipv4.conf.all.accept_source_route: 0
-  net.ipv4.conf.default.accept_source_route: 0
-
-  # Accepting redirects can lead to malicious networking behavior, so disable
-  # it if not needed. | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
-  net.ipv4.conf.default.accept_redirects: 0
-  net.ipv4.conf.all.accept_redirects: 0
-  net.ipv4.conf.all.secure_redirects: 0
-  net.ipv4.conf.default.secure_redirects: 0
-  net.ipv6.conf.default.accept_redirects: 0
-  net.ipv6.conf.all.accept_redirects: 0
-
-  # For non-routers: don't send redirects, these settings are 0 | sysctl-16
-  net.ipv4.conf.all.send_redirects: 0
-  net.ipv4.conf.default.send_redirects: 0
-
-  # log martian packets | sysctl-17
-  net.ipv4.conf.all.log_martians: 1
-  net.ipv4.conf.default.log_martians: 1
-
-  # ipv6 config
-  # Disable acceptance of IPv6 router solicitations messages | sysctl-21
-  net.ipv6.conf.default.router_solicitations: 0
-
-  # Disable Accept Router Preference from router advertisement | sysctl-22
-  net.ipv6.conf.default.accept_ra_rtr_pref: 0
-
-  # Disable learning Prefix Information from router advertisement | sysctl-23
-  net.ipv6.conf.default.accept_ra_pinfo: 0
-
-  # Disable learning Hop limit from router advertisement | sysctl-24
-  net.ipv6.conf.default.accept_ra_defrtr: 0
-
-  # Disable IPv6 autoconfiguration | sysctl-26
-  net.ipv6.conf.default.autoconf: 0
-
-  # Disable neighbor solicitations to send out per address | sysctl-27
-  net.ipv6.conf.default.dad_transmits: 0
-
-  # Assign one global unicast IPv6 addresses to each interface | sysctl-28
-  net.ipv6.conf.default.max_addresses: 1
-
-  # This settings controls how the kernel behaves towards module changes at
+  # This setting controls how the kernel behaves towards module changes at
   # runtime. Setting to 1 will disable module loading at runtime.
   # Setting it to 0 is actually never supported. | sysctl-29
   # kernel.modules_disabled: 1
@@ -167,14 +110,8 @@ sysctl_config:
   # * **256** - nicing of all RT tasks
   kernel.sysrq: 0
 
-  # Prevent core dumps with SUID. These are usually only
-  # needed by developers and may contain sensitive information. | sysctl-31
-  fs.suid_dumpable: 0
-
   # Virtual memory regions protection | sysctl-32
   kernel.randomize_va_space: 2
-
-  kernel.core_uses_pid: 1
 
   # The PTRACE system is used for debugging.  With it, a single user process
   # can attach to any other dumpable process owned by the same user.  In the
@@ -200,6 +137,97 @@ sysctl_config:
   # kernel.yama.ptrace_scope = 1
   kernel.yama.ptrace_scope: 1
 
+  # Disable IPv4 traffic forwarding. | sysctl-01
+  net.ipv4.ip_forward: 0
+
+  # Enable RFC-recommended source validation feature. | sysctl-02
+  net.ipv4.conf.all.rp_filter: 1
+  net.ipv4.conf.default.rp_filter: 1
+
+  # Reduce the surface on SMURF attacks. | sysctl-04
+  # Make sure to ignore ECHO broadcasts, which are only required in broad network analysis.
+  net.ipv4.icmp_echo_ignore_broadcasts: 1
+
+  # There is no reason to accept bogus error responses from ICMP, so ignore them instead. | sysctl-03
+  net.ipv4.icmp_ignore_bogus_error_responses: 1
+
+  # Limit the amount of traffic the system uses for ICMP. | sysctl-05
+  net.ipv4.icmp_ratelimit: 100
+
+  # Adjust the ICMP ratelimit to include ping, dst unreachable,
+  # source quench, ime exceed, param problem, timestamp reply, information reply | sysctl-06
+  net.ipv4.icmp_ratemask: 88089
+
+  # Protect against wrapping sequence numbers at gigabit speeds | sysctl-07
+  net.ipv4.tcp_timestamps: 0
+
+  # Define restriction level for announcing the local source IP | sysctl-08
+  net.ipv4.conf.all.arp_ignore: 1
+
+  # Define mode for sending replies in response to
+  # received ARP requests that resolve local target IP addresses | sysctl-09
+  net.ipv4.conf.all.arp_announce: 2
+
+  # RFC 1337 fix F1 | sysctl-10
+  net.ipv4.tcp_rfc1337: 1
+
+  # Send(router) or accept(host) RFC1620 shared media redirects | sysctl-12
+  net.ipv4.conf.all.shared_media: 1
+  net.ipv4.conf.default.shared_media: 1
+
+  # Accepting source route can lead to malicious networking behavior,
+  # so disable it if not needed. | sysctl-13
+  net.ipv4.conf.all.accept_source_route: 0
+  net.ipv4.conf.default.accept_source_route: 0
+
+  # For non-routers: don't send redirects, these settings are 0 | sysctl-16
+  net.ipv4.conf.all.send_redirects: 0
+  net.ipv4.conf.default.send_redirects: 0
+
+  # log martian packets | sysctl-17
+  net.ipv4.conf.all.log_martians: 1
+  net.ipv4.conf.default.log_martians: 1
+
+  # Accepting redirects can lead to malicious networking behavior, so disable
+  # it if not needed. | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
+  net.ipv4.conf.default.accept_redirects: 0
+  net.ipv4.conf.all.accept_redirects: 0
+  net.ipv4.conf.all.secure_redirects: 0
+  net.ipv4.conf.default.secure_redirects: 0
+  net.ipv6.conf.default.accept_redirects: 0
+  net.ipv6.conf.all.accept_redirects: 0
+
+  # Disable IPv6 | sysctl-18
+  net.ipv6.conf.all.disable_ipv6: 1
+
+  # Disable IPv6 traffic forwarding. | sysctl-19
+  net.ipv6.conf.all.forwarding: 0
+
+  # ignore RAs on Ipv6. | sysctl-25
+  net.ipv6.conf.all.accept_ra: 0
+  net.ipv6.conf.default.accept_ra: 0
+
+  # Disable acceptance of IPv6 router solicitations messages | sysctl-21
+  net.ipv6.conf.default.router_solicitations: 0
+
+  # Disable Accept Router Preference from router advertisement | sysctl-22
+  net.ipv6.conf.default.accept_ra_rtr_pref: 0
+
+  # Disable learning Prefix Information from router advertisement | sysctl-23
+  net.ipv6.conf.default.accept_ra_pinfo: 0
+
+  # Disable learning Hop limit from router advertisement | sysctl-24
+  net.ipv6.conf.default.accept_ra_defrtr: 0
+
+  # Disable IPv6 autoconfiguration | sysctl-26
+  net.ipv6.conf.default.autoconf: 0
+
+  # Disable neighbor solicitations to send out per address | sysctl-27
+  net.ipv6.conf.default.dad_transmits: 0
+
+  # Assign one global unicast IPv6 addresses to each interface | sysctl-28
+  net.ipv6.conf.default.max_addresses: 1
+
   # Protect the zero page of memory from userspace mmap to prevent kernel
   # NULL-dereference attacks against potential future kernel security
   # vulnerabilities.  (Added in kernel 2.6.23.)
@@ -210,38 +238,11 @@ sysctl_config:
   # is reset to the secure default each time the sysctl values are loaded.
   vm.mmap_min_addr: 65536
 
-  # These settings eliminate an entire class of security vulnerability:
-  # time-of-check-time-of-use cross-privilege attacks using guessable
-  # filenames (generally seen as "/tmp file race" vulnerabilities).
-  fs.protected_hardlinks: 1
-  fs.protected_symlinks: 1
-
   # These settings are set to the maximum supported value in order to
   # improve ASLR effectiveness for mmap, at the cost of increased
   # address-space fragmentation. | Tail-1
   vm.mmap_rnd_bits: 32
   vm.mmap_rnd_compat_bits: 16
-
-  # When an attacker is trying to exploit the local kernel, it is often
-  # helpful to be able to examine where in memory the kernel, modules,
-  # and data structures live. As such, kernel addresses should be treated
-  # as sensitive information.
-  #
-  # Many files and interfaces contain these addresses (e.g. /proc/kallsyms,
-  # /proc/modules, etc), and this setting can censor the addresses. A value
-  # of "0" allows all users to see the kernel addresses. A value of "1"
-  # limits visibility to the root user, and "2" blocks even the root user.
-  #
-  # Some off-the-shelf malware exploit kernel addresses exposed
-  # via /proc/kallsyms so by not making these addresses easily available
-  # we increase the cost of such attack some what; now such malware has
-  # to check which kernel Tails is running and then fetch the corresponding
-  # kernel address map from some external source. This is not hard,
-  # but certainly not all malware has such functionality. | Tails-2
-  kernel.kptr_restrict: 2
-
-  # kexec is dangerous: it enables replacement of the running kernel. | Tails-3
-  kernel.kexec_load_disabled: 1
 
 # Do not delete the following line or otherwise the playbook will fail
 # at task 'create a combined sysctl-dict if overwrites are defined'

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -19,13 +19,13 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: true if IPv6 is needed. `ssh_listen_to` must also be set to listen to IPv6 addresses (for example `[::]`).
 - `ssh_client_config_file`
   - Default: `'/etc/ssh/ssh_config'`
-  - Description: path of the ssh client configuration file, e.g. `/etc/ssh/ssh_config.d/custom.conf`
+  - Description: path of the ssh client configuration file, e.g. `/etc/ssh/ssh_config.d/custom.conf`.
 - `ssh_server_config_file`
   - Default: `'/etc/ssh/sshd_config'`
-  - Description: path of the ssh server configuration file, e.g. `/etc/ssh/sshd_config.d/custom.conf`
+  - Description: path of the ssh server configuration file, e.g. `/etc/ssh/sshd_config.d/custom.conf`.
 - `ssh_server_ports`
   - Default: `['22']`
-  - Description: ports on which ssh-server should listen
+  - Description: ports on which ssh-server should listen.
 - `ssh_client_port`
   - Default: `'22'`
   - Description: Specifies the port number to connect on the remote host.
@@ -34,19 +34,19 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: one or more ip addresses, to which ssh-server should listen to. Default is all IPv4 adresses, but should be configured to specific addresses for security reasons!
 - `ssh_host_key_files`
   - Default: `[]`
-  - Description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version
+  - Description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version.
 - `ssh_host_key_algorithms`
   - Default: `[]`
-  - Description: Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms
+  - Description: Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms.
 - `ssh_client_alive_interval`
   - Default: `600`
-  - Description: specifies an interval for sending keepalive messages
+  - Description: specifies an interval for sending keepalive messages.
 - `ssh_client_alive_count`
   - Default: `3`
-  - Description: defines how often keep-alive messages are sent
+  - Description: defines how often keep-alive messages are sent.
 - `ssh_permit_tunnel`
   - Default: `false`
-  - Description: true if SSH Port Tunneling is required
+  - Description: true if SSH Port Tunneling is required.
 - `ssh_remote_hosts`
   - Default: `[]`
   - Description: one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`.
@@ -106,52 +106,52 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: list of hashes containing file paths and authorized principals, see `default_custom.yml` for all options. Only used if `ssh_authorized_principals_file` is set.
 - `ssh_print_motd`
   - Default: `false`
-  - Description: false to disable printing of the MOTD
+  - Description: false to disable printing of the MOTD.
 - `ssh_print_pam_motd`
   - Default: `false`
-  - Description: false to disable printing of the MOTD via pam (Debian and Ubuntu)
+  - Description: false to disable printing of the MOTD via pam (Debian and Ubuntu).
 - `ssh_print_last_log`
   - Default: `false`
-  - Description: false to disable display of last login information
+  - Description: false to disable display of last login information.
 - `sftp_enabled`
   - Default: `false`
-  - Description: true to enable sftp configuration
+  - Description: true to enable sftp configuration.
 - `sftp_umask`
   - Default: `'0027'`
-  - Description: Specifies the umask for sftp
+  - Description: Specifies the umask for sftp.
 - `sftp_chroot`
   - Default: `true`
-  - Description: false to disable chroot for sftp
+  - Description: false to disable chroot for sftp.
 - `sftp_chroot_dir`
   - Default: `/home/%u`
-  - Description: change default sftp chroot location
+  - Description: change default sftp chroot location.
 - `ssh_client_roaming`
   - Default: `false`
-  - Description: enable experimental client roaming
+  - Description: enable experimental client roaming.
 - `sshd_moduli_file`
   - Default: `'/etc/ssh/moduli'`
-  - Description: path to the SSH moduli file
+  - Description: path to the SSH moduli file.
 - `sshd_moduli_minimum`
   - Default: `2048`
-  - Description: remove Diffie-Hellman parameters smaller than the defined size to mitigate logjam
+  - Description: remove Diffie-Hellman parameters smaller than the defined size to mitigate logjam.
 - `ssh_challengeresponseauthentication`
   - Default: `false`
-  - Description: Specifies whether challenge-response authentication is allowed (e.g. via PAM)
+  - Description: Specifies whether challenge-response authentication is allowed (e.g. via PAM).
 - `ssh_client_password_login`
   - Default: `false`
-  - Description: `true` to allow password-based authentication with the ssh client
+  - Description: `true` to allow password-based authentication with the ssh client.
 - `ssh_server_password_login`
   - Default: `false`
-  - Description: `true` to allow password-based authentication to the ssh server. You probably also need to change `sshd_authenticationmethods` to include `password` if you set `ssh_server_password_login`: `true`
+  - Description: `true` to allow password-based authentication to the ssh server. You probably also need to change `sshd_authenticationmethods` to include `password` if you set `ssh_server_password_login`: `true`.
 - `ssh_banner`
   - Default: `false`
-  - Description: `true` to print a banner on login
+  - Description: `true` to print a banner on login.
 - `ssh_banner_path`
   - Default: `'/etc/sshd/banner.txt'`
-  - Description: path to the SSH banner file
+  - Description: path to the SSH banner file.
 - `ssh_client_hardening`
   - Default: `true`
-  - Description: `false` to stop harden the client
+  - Description: `false` to stop harden the client.
 - `ssh_client_compression`
   - Default: `false`
   - Description: Specifies whether the client requests compression.
@@ -160,7 +160,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: Specifies whether server-side compression is enabled after the user has authenticated successfully.
 - `ssh_login_grace_time`
   - Default: `30s`
-  - Description: specifies the time allowed for successful authentication to the SSH server
+  - Description: specifies the time allowed for successful authentication to the SSH server.
 - `ssh_max_auth_retries`
   - Default: `2`
   - Description: Specifies the maximum number of authentication attempts permitted per connection.
@@ -169,13 +169,13 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: Specifies the maximum number of open sessions permitted from a given connection.
 - `ssh_print_debian_banner`
   - Default: `false`
-  - Description: `true` to print debian specific banner
+  - Description: `true` to print debian specific banner.
 - `ssh_server_enabled`
   - Default: `true`
-  - Description: `false` to disable the opensshd server
+  - Description: `false` to disable the opensshd server.
 - `ssh_server_hardening`
   - Default: `true`
-  - Description: `false` to stop harden the server
+  - Description: `false` to stop harden the server.
 - `ssh_server_match_address`
   - Default: `''`
   - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
@@ -190,10 +190,10 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
 - `ssh_server_permit_environment_vars`
   - Default: `no`
-  - Description: `yes` to specify that ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. With openssh version 7.8 it is possible to specify a whitelist of environment variable names in addition to global "yes" or "no" settings
+  - Description: `yes` to specify that ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. With openssh version 7.8 it is possible to specify a whitelist of environment variable names in addition to global "yes" or "no" settings.
 - `ssh_server_accept_env_vars`
   - Default: `''`
-  - Description: Specifies what environment variables sent by the client will be copied into the session's environment, multiple environment variables may be separated by whitespace
+  - Description: Specifies what environment variables sent by the client will be copied into the session's environment, multiple environment variables may be separated by whitespace.
 - `ssh_use_dns`
   - Default: `false`
   - Description: Specifies whether sshd should look up the remote host name, and to check that the resolved host name for the remote IP address maps back to the very same IP address.
@@ -205,31 +205,31 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: Specifies the maximum number of concurrent unauthenticated connections to the SSH daemon.
 - `ssh_macs`
   - Default: `[]`
-  - Description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`
+  - Description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`.
 - `ssh_kex`
   - Default: `[]`
-  - Description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
+  - Description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`.
 - `ssh_ciphers`
   - Default: `[]`
-  - Description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`
+  - Description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`.
 - `ssh_custom_options`
   - Default: `[]`
-  - Description: Custom lines for SSH client configuration
+  - Description: Custom lines for SSH client configuration.
 - `sshd_custom_options`
   - Default: `[]`
-  - Description: Custom lines for SSH daemon configuration
+  - Description: Custom lines for SSH daemon configuration.
 - `sshd_syslog_facility`
   - Default: `'AUTH'`
-  - Description: The facility code that is used when logging messages from sshd
+  - Description: The facility code that is used when logging messages from sshd.
 - `sshd_log_level`
   - Default: `'VERBOSE'`
-  - Description: the verbosity level that is used when logging messages from sshd
+  - Description: the verbosity level that is used when logging messages from sshd.
 - `sshd_strict_modes`
   - Default: `true`
-  - Description: Check file modes and ownership of the user's files and home directory before accepting login
+  - Description: Check file modes and ownership of the user's files and home directory before accepting login.
 - `sshd_authenticationmethods`
   - Default: `publickey`
-  - Description: Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml`
+  - Description: Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml`.
 
 ## Example Playbook
 


### PR DESCRIPTION
Some lists in alphabetical order.

Added a dot after each sentence in the variable descriptions in the READMEs.
Almost one half of the sentences ended in a dot while the other half did not...

This PR is related to #359