### PR TITLE
Regenerate RSA key with size 4096 bits

### DIFF
--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -1,19 +1,21 @@
 ---
-- name: remove default 2048 bits RSA hostkey
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
-    - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key.pub"
+- name: replace default 2048 bits RSA keypair with 4096 bits keypair
+  openssh_keypair:
+    state: present
+    type: rsa
+    size: 4096
+    path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
+    force: false
+    regenerate: partial_idempotence
 
-- name: generate recommended 4096 bits RSA hostkey
-  shell:
-    cmd: 'ssh-keygen -q -t rsa -b 4096 -f ssh_host_rsa_key -N "" < /dev/null'
-    chdir: "{{ ssh_host_keys_dir }}"
-  register: result
-  changed_when:
-    - result.rc == 0
+# In RHEL and Fedora, the 'ssh_keys' group is the group owner of the host private SSH keys.
+# Since the openssh_keypair module needs to read the key to provide idempotency, we need to set ownership and group based on specific OS vars.
+- name: change host private key ownership, group and permissions
+  file:
+    path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
+    owner: "{{ ssh_host_keys_owner }}"
+    group: "{{ ssh_host_keys_group }}"
+    mode: "0600"
 
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -15,7 +15,7 @@
     path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
     owner: "{{ ssh_host_keys_owner }}"
     group: "{{ ssh_host_keys_group }}"
-    mode: "0600"
+    mode: "0640"
 
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -11,7 +11,7 @@
   shell:
     cmd: 'ssh-keygen -q -t rsa -b 4096 -f ssh_host_rsa_key -N "" < /dev/null'
     chdir: "{{ ssh_host_keys_dir }}"
-  
+
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:
     ssh_host_key_files:

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -16,6 +16,7 @@
     owner: "{{ ssh_host_keys_owner }}"
     group: "{{ ssh_host_keys_group }}"
     mode: "0640"
+  when: "ansible_facts.distribution in ['CentOS', 'OracleLinux', 'RedHat']"
 
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -11,6 +11,9 @@
   shell:
     cmd: 'ssh-keygen -q -t rsa -b 4096 -f ssh_host_rsa_key -N "" < /dev/null'
     chdir: "{{ ssh_host_keys_dir }}"
+  register: result
+  changed_when:
+    - result.rc == 0
 
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -1,4 +1,17 @@
 ---
+- name: remove default 2048 bits RSA hostkey
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
+    - "{{ ssh_host_keys_dir }}/ssh_host_rsa_key.pub"
+
+- name: generate recommended 4096 bits RSA hostkey
+  shell:
+    cmd: 'ssh-keygen -q -t rsa -b 4096 -f ssh_host_rsa_key -N "" < /dev/null'
+    chdir: "{{ ssh_host_keys_dir }}"
+  
 - name: set hostkeys according to openssh-version if openssh >= 5.3
   set_fact:
     ssh_host_key_files:

--- a/roles/ssh_hardening/vars/Archlinux.yml
+++ b/roles/ssh_hardening/vars/Archlinux.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Debian.yml
+++ b/roles/ssh_hardening/vars/Debian.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Fedora.yml
+++ b/roles/ssh_hardening/vars/Fedora.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'ssh_keys'
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/FreeBSD.yml
+++ b/roles/ssh_hardening/vars/FreeBSD.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/OpenBSD.yml
+++ b/roles/ssh_hardening/vars/OpenBSD.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 
 # true if SSH support Kerberos
 ssh_kerberos_support: false

--- a/roles/ssh_hardening/vars/RedHat.yml
+++ b/roles/ssh_hardening/vars/RedHat.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'ssh_keys'
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_8.yml
+++ b/roles/ssh_hardening/vars/RedHat_8.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'ssh_keys'
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/SmartOS.yml
+++ b/roles/ssh_hardening/vars/SmartOS.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/var/ssh'
 sshd_service_name: ssh
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Suse.yml
+++ b/roles/ssh_hardening/vars/Suse.yml
@@ -4,6 +4,8 @@ ssh_host_keys_dir: '/etc/ssh'
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'root'
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true


### PR DESCRIPTION
According to [NIST standards](https://www.keylength.com/en/4/), achieving a security strength of 128 (2019 - 2030 & beyond) requires a factoring modulus with a length of at least 3072 bits, and since there is no major performance difference between RSA of size 2048 bits and RSA of size 4096 bits keys, it's better to ship SSH with RSA key of size 4096 bits.