### PR TITLE
add Support for OpenSSH HostCertificate config option

### DIFF
--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -36,6 +36,9 @@ ssh_listen_to: ['0.0.0.0']          # sshd
 # Host keys to look for when starting sshd.
 ssh_host_key_files: []              # sshd
 
+# Host certificates to look for when starting sshd.
+ssh_host_certificates: []           # sshd
+
 # Specifies the host key algorithms that the server offers
 ssh_host_key_algorithms: []         # sshd
 

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -38,6 +38,7 @@ ListenAddress {{ address }}
 HostKey {{ key }}
 {% endfor %}
 
+# HostCertificates are listed here.
 {% if ssh_host_certificates -%}
 {% for certificate in ssh_host_certificates -%}
 HostCertificate {{ certificate }}

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -39,11 +39,9 @@ HostKey {{ key }}
 {% endfor %}
 
 # HostCertificates are listed here.
-{% if ssh_host_certificates -%}
 {% for certificate in ssh_host_certificates -%}
 HostCertificate {{ certificate }}
-{% endfor -%}
-{% endif %}
+{% endfor %}
 
 # Host key algorithms that the server offers.
 {% if sshd_version is version('5.8', '>=') %}

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -42,7 +42,7 @@ HostKey {{ key }}
 {% for certificate in ssh_host_certificates -%}
 HostCertificate {{ certificate }}
 {% endfor -%}
-{% endif -%}
+{% endif %}
 
 # Host key algorithms that the server offers.
 {% if sshd_version is version('5.8', '>=') %}

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -38,6 +38,12 @@ ListenAddress {{ address }}
 HostKey {{ key }}
 {% endfor %}
 
+{% if ssh_host_certificates -%}
+{% for certificate in ssh_host_certificates -%}
+HostCertificate {{ certificate }}
+{% endfor -%}
+{% endif -%}
+
 # Host key algorithms that the server offers.
 {% if sshd_version is version('5.8', '>=') %}
 {{ "HostKeyAlgorithms " ~ ssh_host_key_algorithms|join(',') if ssh_host_key_algorithms else "HostKeyAlgorithms"|comment }}


### PR DESCRIPTION
This PR adds support for HostCertificate in sshd_config so that setups with an SSH CA in place may use host certificates in addition to HostKeys.

