### PR TITLE
run labeler workflow with higher privileges

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,7 +1,7 @@
 name: "Enforce PR labels"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:


### PR DESCRIPTION
this allows PRs from forks to be labeled correctly.

explaination: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

The warning is not really relevant here, since the action is not problematic and we would need to merge changes to master for this to pose an issue.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>