### PR TITLE
Ensuring that permissions on SSH public and private host key files ar…

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -129,3 +129,31 @@
   when:
     - sshd_disable_crypto_policy | bool
     - ('crypto-policies' in ansible_facts.packages)
+
+- name: find private SSH host keys.
+  find:
+    paths: /etc/ssh
+    patterns: 'ssh_host_*_key'
+  register: ssh_keys_private
+
+- name: ensure permissions on SSH private host key files are configured - CIS 5.2.3
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: root
+    group: root
+    mode: '0600'
+  with_items: "{{ ssh_keys_private.files }}"
+
+- name: find public SSH host keys.
+  find:
+    paths: /etc/ssh
+    patterns: 'ssh_host_*_key.pub'
+  register: ssh_keys_public
+
+- name: ensure permissions on SSH public host key files are configured - CIS 5.2.4
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: root
+    group: root
+    mode: '0644'
+  with_items: "{{ ssh_keys_public.files }}"


### PR DESCRIPTION
…e configured.

### 5.2.3 Ensure permissions on SSH public host key files are configured
(Scored)
Profile Applicability:
Level 1 - Server
Level 1 - Workstation
#### Description:
An SSH public key is one of two files used in SSH public key authentication. In this
authentication method, a public key is a key that can be used for verifying digital signatures
generated using a corresponding private key. Only a public key that corresponds to a
private key will be able to authenticate successfully.

#### Rationale:
If a public host key file is modified by an unauthorized user, the SSH service may be
compromised.

#### Comments
Debian does this right out of the box. So running this on a fresh install of debian doesn't change anything.
RHEL/CentOS 7/8 changes the private key permissions:
```
qemu: TASK [devsec.hardening.ssh_hardening : ensure permissions on SSH private host key files are configured - CIS 5.2.3] ***
    qemu: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ed25519_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 387, 'inode': 450894, 'dev': 64768, 'nlink': 1, 'atime': 1611673480.4316604, 'mtime': 1611673478.907, 'ctime': 1611673478.92, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ecdsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 480, 'inode': 450896, 'dev': 64768, 'nlink': 1, 'atime': 1611673480.4316604, 'mtime': 1611673478.919, 'ctime': 1611673478.933, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu: changed: [default] => (item={'path': '/etc/ssh/ssh_host_rsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 3357, 'inode': 450898, 'dev': 64768, 'nlink': 1, 'atime': 1611673600.2054858, 'mtime': 1611673600.200486, 'ctime': 1611673600.200486, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu:
    qemu: TASK [devsec.hardening.ssh_hardening : find public SSH host keys.] *************
    qemu: ok: [default]
    qemu:
    qemu: TASK [devsec.hardening.ssh_hardening : ensure permissions on SSH public host key files are configured - CIS 5.2.4] ***
    qemu: ok: [default]
```

Signed-off-by: Farid Joubbi <farid@joubbi.se>