### PR TITLE
use version tag for changelog action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate changelog
-        uses: charmixer/auto-changelog-action@master
+        uses: charmixer/auto-changelog-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           future_release: ${{ steps.version.outputs.next-version }}
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate changelog for the release
-        uses: charmixer/auto-changelog-action@master
+        uses: charmixer/auto-changelog-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           since_tag: ${{ steps.previoustag.outputs.tag }}


### PR DESCRIPTION
Referencing actions by the short SHA will be deprecated soon

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>