### PR TITLE
use fqcn for community.crypto.openssh_keypair module

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  community.crypto: '>=1.0.0'
 
 # The URL of the originating SCM repository
 repository: https://github.com/dev-sec/ansible-os-hardening

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -1,6 +1,6 @@
 ---
 - name: replace default 2048 bits RSA keypair with 4096 bits keypair
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     state: present
     type: rsa
     size: 4096


### PR DESCRIPTION
tihis fixes a problem with Ansible 2.9 where the default openssh_keypair
is not supporting every option we need

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>