### PR TITLE
Set default for ssh host key files only when hardening the server

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -33,7 +33,9 @@
 
 - name: set default for ssh_host_key_files if not supplied
   include_tasks: crypto_hostkeys.yml
-  when: not ssh_host_key_files
+  when:
+    - ssh_server_hardening | bool
+    - not ssh_host_key_files
 
 - name: set default for ssh_macs if not supplied
   include_tasks: crypto_macs.yml


### PR DESCRIPTION
When hardening the ssh client only (i.e. `ssh_server_hardening: false` and `ssh_client_hardening: true`) the default for ssh host key files won't be set any longer.