### PR TITLE
Add variable to specify SSH host RSA key size

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -35,6 +35,9 @@ Warning: This role disables root-login on the target server! Please make sure yo
 - `ssh_host_key_files`
   - Default: `[]`
   - Description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version.
+- `ssh_host_rsa_key_size`
+  - Default: `4096`
+  - Description: Specifies the number of bits in the private host RSA key to create.
 - `ssh_host_key_algorithms`
   - Default: `[]`
   - Description: Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms.

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -36,6 +36,9 @@ ssh_listen_to: ['0.0.0.0']          # sshd
 # Host keys to look for when starting sshd.
 ssh_host_key_files: []              # sshd
 
+# Host RSA key size in bits
+ssh_host_rsa_key_size: 4096         # sshd
+
 # Host certificates to look for when starting sshd.
 ssh_host_certificates: []           # sshd
 

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -1,9 +1,9 @@
 ---
-- name: replace default 2048 bits RSA keypair with 4096 bits keypair
+- name: replace default 2048 bits RSA keypair
   community.crypto.openssh_keypair:
     state: present
     type: rsa
-    size: 4096
+    size: "{{ ssh_host_rsa_key_size }}"
     path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
     force: false
     regenerate: partial_idempotence


### PR DESCRIPTION
This PR adds a variable `ssh_host_rsa_key_size` (default: `4096`) to specify the host RSA key size in bits. It allows the user to use larger keys or temporarily continue using the existing key.