### PR TITLE
Extend GSSAPI configuration support to ssh_config

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -76,7 +76,10 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: false to disable pam authentication.
 - `ssh_gssapi_support`
   - Default: `false`
-  - Description: true if SSH has GSSAPI support.
+  - Description: Set to true to enable GSSAPI authentication (both client and server).
+- `ssh_gssapi_delegation`
+  - Default: `false`
+  - Description: Set to true to enable GSSAPI credential forwarding.
 - `ssh_kerberos_support`
   - Default: `true`
   - Description: true if SSH has Kerberos support.

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -91,8 +91,11 @@ ssh_use_pam: true                   # sshd
 # specify AuthenticationMethods
 sshd_authenticationmethods: 'publickey'
 
-# true if SSH support GSSAPI
+# Set to true to enable GSSAPI authentication (both client and server)
 ssh_gssapi_support: false
+
+# Set to true to enable GSSAPI credential forwarding
+ssh_gssapi_delegation: false
 
 # if specified, login is disallowed for user names that match one of the patterns.
 ssh_deny_users: ''                  # sshd

--- a/roles/ssh_hardening/templates/openssh.conf.j2
+++ b/roles/ssh_hardening/templates/openssh.conf.j2
@@ -104,8 +104,8 @@ RSAAuthentication yes
 PasswordAuthentication {{ 'yes' if ssh_client_password_login else 'no' }}
 
 # Only use GSSAPIAuthentication if implemented on the network.
-GSSAPIAuthentication {{ 'yes' if ssh_gssapi_support else 'no' }}
-GSSAPIDelegateCredentials {{ 'yes' if ssh_gssapi_support else 'no' }}
+GSSAPIAuthentication {{ 'yes' if (ssh_gssapi_support|bool) else 'no' }}
+GSSAPIDelegateCredentials {{ 'yes' if (ssh_gssapi_delegation|bool) else 'no' }}
 
 # Disable tunneling
 Tunnel no

--- a/roles/ssh_hardening/templates/openssh.conf.j2
+++ b/roles/ssh_hardening/templates/openssh.conf.j2
@@ -104,8 +104,8 @@ RSAAuthentication yes
 PasswordAuthentication {{ 'yes' if ssh_client_password_login else 'no' }}
 
 # Only use GSSAPIAuthentication if implemented on the network.
-GSSAPIAuthentication no
-GSSAPIDelegateCredentials no
+GSSAPIAuthentication {{ 'yes' if ssh_gssapi_support else 'no' }}
+GSSAPIDelegateCredentials {{ 'yes' if ssh_gssapi_support else 'no' }}
 
 # Disable tunneling
 Tunnel no


### PR DESCRIPTION
Previously, the ssh_gssapi_support variable only toggled the GSSAPI
settings in sshd_config.

Through this change, setting ssh_gssapi_support to true also enables
support in ssh_config. 

It enables both authentication and credential delegation.