### PR TITLE
Ensure permissions on /etc/crontab are configured

### DIFF
--- a/roles/os_hardening/tasks/cron.yml
+++ b/roles/os_hardening/tasks/cron.yml
@@ -15,7 +15,7 @@
     path: /etc/crontab
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_crontab.stat.exists
 
 - name: Check if /etc/cron.hourly exists
@@ -28,7 +28,7 @@
     path: /etc/cron.hourly
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_cron_hourly.stat.exists
 
 - name: Check if /etc/cron.daily exists
@@ -41,7 +41,7 @@
     path: /etc/cron.daily
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_cron_daily.stat.exists
 
 - name: Check if /etc/cron.weekly exists
@@ -54,7 +54,7 @@
     path: /etc/cron.weekly
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_cron_weekly.stat.exists
 
 - name: Check if /etc/cron.monthly exists
@@ -67,7 +67,7 @@
     path: /etc/cron.monthly
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_cron_monthly.stat.exists
 
 - name: Check if /etc/cron.d exists
@@ -80,5 +80,5 @@
     path: /etc/cron.d
     owner: root
     group: root
-    mode: '0600'
+    mode: og-rwx
   when: osh_cron_d.stat.exists

--- a/roles/os_hardening/tasks/cron.yml
+++ b/roles/os_hardening/tasks/cron.yml
@@ -1,0 +1,84 @@
+---
+# Granting write access to this directory for non-privileged users could provide
+# them the means for gaining unauthorized elevated privileges.
+# Granting read access to this directory could give an unprivileged user insight
+# in how to gain elevated privileges or circumvent auditing controls.
+# CIS 5.1.2 - CIS 5.1.7
+#
+- name: Check if /etc/crontab exists
+  stat:
+    path: /etc/crontab
+  register: osh_crontab
+
+- name: Ensure permissions on /etc/crontab are configured
+  ansible.builtin.file:
+    path: /etc/crontab
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_crontab.stat.exists
+
+- name: Check if /etc/cron.hourly exists
+  stat:
+    path: /etc/cron.hourly
+  register: osh_cron_hourly
+
+- name: Ensure permissions on /etc/cron.hourly are configured
+  ansible.builtin.file:
+    path: /etc/cron.hourly
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_cron_hourly.stat.exists
+
+- name: Check if /etc/cron.daily exists
+  stat:
+    path: /etc/cron.daily
+  register: osh_cron_daily
+
+- name: Ensure permissions on /etc/cron.daily are configured
+  ansible.builtin.file:
+    path: /etc/cron.daily
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_cron_daily.stat.exists
+
+- name: Check if /etc/cron.weekly exists
+  stat:
+    path: /etc/cron.weekly
+  register: osh_cron_weekly
+
+- name: Ensure permissions on /etc/cron.weekly are configured
+  ansible.builtin.file:
+    path: /etc/cron.weekly
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_cron_weekly.stat.exists
+
+- name: Check if /etc/cron.monthly exists
+  stat:
+    path: /etc/cron.monthly
+  register: osh_cron_monthly
+
+- name: Ensure permissions on /etc/cron.monthly are configured
+  ansible.builtin.file:
+    path: /etc/cron.monthly
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_cron_monthly.stat.exists
+
+- name: Check if /etc/cron.d exists
+  stat:
+    path: /etc/cron.d
+  register: osh_cron_d
+
+- name: Ensure permissions on /etc/cron.d are configured
+  ansible.builtin.file:
+    path: /etc/cron.d
+    owner: root
+    group: root
+    mode: '0600'
+  when: osh_cron_d.stat.exists

--- a/roles/os_hardening/tasks/cron.yml
+++ b/roles/os_hardening/tasks/cron.yml
@@ -5,80 +5,24 @@
 # in how to gain elevated privileges or circumvent auditing controls.
 # CIS 5.1.2 - CIS 5.1.7
 #
-- name: Check if /etc/crontab exists
-  stat:
-    path: /etc/crontab
-  register: osh_crontab
+- name: Find cron files and directories
+  find:
+    paths:
+      - /etc
+    patterns:
+      - cron.hourly
+      - cron.daily
+      - cron.weekly
+      - cron.monthly
+      - cron.d
+      - crontab
+    file_type: any
+  register: cron_directories
 
-- name: Ensure permissions on /etc/crontab are configured
+- name: Ensure permissions on /etc/cron are configured
   ansible.builtin.file:
-    path: /etc/crontab
+    path: "{{ item.path }}"
     owner: root
     group: root
     mode: og-rwx
-  when: osh_crontab.stat.exists
-
-- name: Check if /etc/cron.hourly exists
-  stat:
-    path: /etc/cron.hourly
-  register: osh_cron_hourly
-
-- name: Ensure permissions on /etc/cron.hourly are configured
-  ansible.builtin.file:
-    path: /etc/cron.hourly
-    owner: root
-    group: root
-    mode: og-rwx
-  when: osh_cron_hourly.stat.exists
-
-- name: Check if /etc/cron.daily exists
-  stat:
-    path: /etc/cron.daily
-  register: osh_cron_daily
-
-- name: Ensure permissions on /etc/cron.daily are configured
-  ansible.builtin.file:
-    path: /etc/cron.daily
-    owner: root
-    group: root
-    mode: og-rwx
-  when: osh_cron_daily.stat.exists
-
-- name: Check if /etc/cron.weekly exists
-  stat:
-    path: /etc/cron.weekly
-  register: osh_cron_weekly
-
-- name: Ensure permissions on /etc/cron.weekly are configured
-  ansible.builtin.file:
-    path: /etc/cron.weekly
-    owner: root
-    group: root
-    mode: og-rwx
-  when: osh_cron_weekly.stat.exists
-
-- name: Check if /etc/cron.monthly exists
-  stat:
-    path: /etc/cron.monthly
-  register: osh_cron_monthly
-
-- name: Ensure permissions on /etc/cron.monthly are configured
-  ansible.builtin.file:
-    path: /etc/cron.monthly
-    owner: root
-    group: root
-    mode: og-rwx
-  when: osh_cron_monthly.stat.exists
-
-- name: Check if /etc/cron.d exists
-  stat:
-    path: /etc/cron.d
-  register: osh_cron_d
-
-- name: Ensure permissions on /etc/cron.d are configured
-  ansible.builtin.file:
-    path: /etc/cron.d
-    owner: root
-    group: root
-    mode: og-rwx
-  when: osh_cron_d.stat.exists
+  with_items: "{{ cron_directories.files }}"

--- a/roles/os_hardening/tasks/cron.yml
+++ b/roles/os_hardening/tasks/cron.yml
@@ -19,7 +19,7 @@
     file_type: any
   register: cron_directories
 
-- name: Ensure permissions on /etc/cron are configured
+- name: Ensure permissions on cron files and directories are configured
   ansible.builtin.file:
     path: "{{ item.path }}"
     owner: root

--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -25,6 +25,9 @@
   tags: auditd
   when: os_auditd_enabled | bool
 
+- import_tasks: cron.yml
+  tags: cron
+
 - import_tasks: limits.yml
   tags: limits
 


### PR DESCRIPTION
See https://github.com/dev-sec/ansible-collection-hardening/issues/375

I'm not sure how to do the baseline change.
I looked at the baseline code and decided to leave it to someone else.
I got unsure about how to define the test since the file/directory (/etc/crontab, /etc/cron.daily...) doesn't have to exist.
The permissions should be correct only if the file/directory exists.