### PR TITLE
Improve Documentation for sysctl defaults

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -137,10 +137,17 @@ sysctl_config:
   # kernel.yama.ptrace_scope = 1
   kernel.yama.ptrace_scope: 1
 
-  # Disable IPv4 traffic forwarding. | sysctl-01
+  # Disable traffic forwarding.
+  # Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard
+  # proxy), will never be able to forward packets, and therefore, never serve as a router.
+  # | sysctl-01 | sysctl-19
   net.ipv4.ip_forward: 0
+  net.ipv6.conf.all.forwarding: 0
 
-  # Enable RFC-recommended source validation feature. | sysctl-02
+  # Enable RFC-recommended source validation feature.
+  # If the return packet does not go out the same interface that the corresponding
+  # source packet came from, the packet is dropped (and logged if log_martians is set).
+  # | sysctl-02
   net.ipv4.conf.all.rp_filter: 1
   net.ipv4.conf.default.rp_filter: 1
 
@@ -148,7 +155,9 @@ sysctl_config:
   # Make sure to ignore ECHO broadcasts, which are only required in broad network analysis.
   net.ipv4.icmp_echo_ignore_broadcasts: 1
 
-  # There is no reason to accept bogus error responses from ICMP, so ignore them instead. | sysctl-03
+  # Some routers (and some attackers) will send responses that violate RFC-1122 and attempt
+  # to fill up a log file system with many useless error messages.
+  # | sysctl-03
   net.ipv4.icmp_ignore_bogus_error_responses: 1
 
   # Limit the amount of traffic the system uses for ICMP. | sysctl-05
@@ -158,7 +167,7 @@ sysctl_config:
   # source quench, ime exceed, param problem, timestamp reply, information reply | sysctl-06
   net.ipv4.icmp_ratemask: 88089
 
-  # Protect against wrapping sequence numbers at gigabit speeds | sysctl-07
+  # Disable TCP timestamps in order to not reveal system uptime. | sysctl-07
   net.ipv4.tcp_timestamps: 0
 
   # Define restriction level for announcing the local source IP | sysctl-08
@@ -188,16 +197,30 @@ sysctl_config:
   net.ipv4.conf.all.accept_source_route: 0
   net.ipv4.conf.default.accept_source_route: 0
 
-  # For non-routers: don't send redirects, these settings are 0 | sysctl-16
+  # For non-routers: don't send redirects.
+  # An attacker could use a compromised host to send invalid ICMP redirects to other
+  # router devices in an attempt to corrupt routing and have users access a system
+  # set up by the attacker as opposed to a valid system.
+  # | sysctl-16
   net.ipv4.conf.all.send_redirects: 0
   net.ipv4.conf.default.send_redirects: 0
 
-  # log martian packets | sysctl-17
+  # log martian packets
+  # This feature logs packets with un-routable source addresses to the kernel log.
+  # Enabling this feature and logging these packets allows an administrator to investigate
+  # the possibility that an attacker is sending spoofed packets to their system.
+  # | sysctl-17
   net.ipv4.conf.all.log_martians: 1
   net.ipv4.conf.default.log_martians: 1
 
   # Accepting redirects can lead to malicious networking behavior, so disable
-  # it if not needed. | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
+  # it if not needed.
+  # Attackers could use bogus ICMP redirect messages to maliciously alter the system
+  # routing tables and get them to send packets to incorrect networks and allow
+  # your system packets to be captured.
+  # Setting net.ipv4.conf.all.secure_redirects to 0 protects the system from
+  # routing table updates by possibly compromised known gateways.
+  # | sysctl-13 | sysctl-14 | sysctl-15 | sysctl-20
   net.ipv4.conf.default.accept_redirects: 0
   net.ipv4.conf.all.accept_redirects: 0
   net.ipv4.conf.all.secure_redirects: 0
@@ -207,9 +230,6 @@ sysctl_config:
 
   # Disable IPv6 | sysctl-18
   net.ipv6.conf.all.disable_ipv6: 1
-
-  # Disable IPv6 traffic forwarding. | sysctl-19
-  net.ipv6.conf.all.forwarding: 0
 
   # ignore RAs on Ipv6. | sysctl-25
   net.ipv6.conf.all.accept_ra: 0


### PR DESCRIPTION
Added text copy pasted from CIS documents to document rationale behind the hardening.

I also moved `net.ipv6.conf.all.forwarding` to group it together with `net.ipv4.ip_forward`.
There is no need to repeat the documentation text this way, also if you want to disable Ipv4 forwarding you most probably want to do it for IPv6 as well.

Signed-off-by: Farid Joubbi <farid@joubbi.se>