### PR TITLE
remove FQCN from roles in examples

### DIFF
--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -24,7 +24,7 @@ It configures:
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.mysql_hardening
+    - mysql_hardening
 ```
 
 This role expects an existing installation of MySQL or MariaDB. Please ensure that the following variables are set accordingly:

--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -83,7 +83,7 @@ It works with the following nginx-roles, including, but not limited to:
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.nginx_hardening
+    - nginx_hardening
 ```
 
 [nginx_client_body_buffer_size]: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -219,7 +219,7 @@ To prevent some of the filesystems from being disabled, add them to the `os_file
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.os_hardening
+    - os_hardening
 ```
 
 ## Changing sysctl variables
@@ -232,7 +232,7 @@ So for example if you want to change the IPv4 traffic forwarding variable to `1`
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.os_hardening
+    - os_hardening
   vars:
     sysctl_overwrite:
       # Enable IPv4 traffic forwarding.

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -244,7 +244,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.ssh_hardening
+    - ssh_hardening
 ```
 
 ## Configuring settings not listed in role-variables
@@ -258,7 +258,7 @@ Example playbook:
   collections:
     - devsec.hardening
   roles:
-    - devsec.hardening.ssh_hardening
+    - ssh_hardening
   vars:
     ssh_custom_options:
       - "Include /etc/ssh/ssh_config.d/*"


### PR DESCRIPTION
Ansible does not work with FQCN and collections sepcified for including
roles. It is currently expecting to only get the role name in this
context.

Verified with Ansible 2.10.5

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>