### PR TITLE
Improve Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,10 @@ jobs:
           fetch-depth: 0
 
       - name: Generate changelog for the release
-        uses: charmixer/auto-changelog-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_tag: ${{ steps.previoustag.outputs.tag }}
-          future_release: ${{ steps.version.outputs.next-version }}
-          output: CHANGELOGRELEASE.md
-          # this excludes all versions prior to the collection-release
-          # since they break the changelog generation with the error:
-          # "No common ancestor between ... and $version"
-          exclude_tags_regex: '[0-6]\.\d\.\d'
+        run: |
+          sed '/## \[${{ steps.previoustag.outputs.tag }}\]/Q' \
+           /mnt/c/Develop/ansible-collection-hardening/CHANGELOG.md \
+           > CHANGELOGRELEASE.md
 
       - name: Read CHANGELOG.md
         id: package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       # changelog gets updated but action works on old commit id
       - uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 0
+          ref: master
 
       - name: Generate changelog for the release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,7 @@ jobs:
 
       - name: Generate changelog for the release
         run: |
-          sed '/## \[${{ steps.previoustag.outputs.tag }}\]/Q' \
-           /mnt/c/Develop/ansible-collection-hardening/CHANGELOG.md \
-           > CHANGELOGRELEASE.md
+          sed '/## \[${{ steps.previoustag.outputs.tag }}\]/Q' CHANGELOG.md > CHANGELOGRELEASE.md
 
       - name: Read CHANGELOG.md
         id: package


### PR DESCRIPTION
in the past we used to call github-changelog-generator twice. This hav many Problems (API Limit, breaking Workflows)

This change only calls github-changelog-generator once and the workflow should never fail when creating the Release in Github