### PR TITLE
Not accepting source routing for IPv6. This was already done for IPv4.

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -196,6 +196,8 @@ sysctl_config:
   # so disable it if not needed. | sysctl-13
   net.ipv4.conf.all.accept_source_route: 0
   net.ipv4.conf.default.accept_source_route: 0
+  net.ipv6.conf.all.accept_source_route: 0
+  net.ipv6.conf.default.accept_source_route: 0
 
   # For non-routers: don't send redirects.
   # An attacker could use a compromised host to send invalid ICMP redirects to other


### PR DESCRIPTION
My guess is that someone forgot to add this for IPv6 when it was added for IPv4.
This is also recommended by CIS.

Signed-off-by: Farid Joubbi <farid@joubbi.se>