### PR TITLE
Use distribution version as default when major version isn't defined

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -5,9 +5,9 @@
     name: 'os_vars'
   with_first_found:
     - files:
-        - '{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml'
+        - '{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version | default(ansible_facts.distribution_version) }}.yml'
         - '{{ ansible_facts.distribution }}.yml'
-        - '{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml'
+        - '{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version | default(ansible_facts.distribution_version) }}.yml'
         - '{{ ansible_facts.os_family }}.yml'
       skip: true
   tags: always


### PR DESCRIPTION
OpenBSD doesn't have an `ansible_facts.distribution_major_version` fact; I think SmartOS is the same way, but haven't confirmed.  For example, here are all the `ansible_distribution*` facts on OpenBSD:

```json
{
  "ansible_distribution": "OpenBSD",
  "ansible_distribution_release": "release",
  "ansible_distribution_version": "6.8"
}
```

In this PR I've changed the distribution version to be used as a fallback default when trying to load variables.  Otherwise, on these platforms Ansible will fail with a cryptic message about `first_found` lookup failing (because it can't template its arguments).