### PR TITLE
add restart-auditd handler after configuration change

### DIFF
--- a/molecule/mysql_hardening/verify.yml
+++ b/molecule/mysql_hardening/verify.yml
@@ -40,7 +40,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/mysql-baseline.git"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit supermarket://dev-sec/mysql-baseline"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/nginx_hardening/verify.yml
+++ b/molecule/nginx_hardening/verify.yml
@@ -43,7 +43,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/nginx-baseline.git"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit supermarket://dev-sec/nginx-baseline"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -47,7 +47,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/linux-baseline.git"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit supermarket://dev-sec/linux-baseline"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/ssh_hardening/verify.yml
+++ b/molecule/ssh_hardening/verify.yml
@@ -38,7 +38,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/ssh-baseline.git"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit supermarket://dev-sec/nginx-baseline"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: update-initramfs
   command: 'update-initramfs -u'
+
+- name: restart-auditd
+  command:
+    cmd: 'service auditd restart' # rhel: see: https://access.redhat.com/solutions/2664811
+    warn: no # sadly 'service' module fails in that case also by using 'use: service'

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -4,5 +4,5 @@
 
 - name: restart-auditd
   command:
-    cmd: 'service auditd restart' # rhel: see: https://access.redhat.com/solutions/2664811
-    warn: no # sadly 'service' module fails in that case also by using 'use: service'
+    cmd: 'service auditd restart'  # rhel: see: https://access.redhat.com/solutions/2664811
+    warn: false  # sadly 'service' module fails in that case also by using 'use: service'

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -6,5 +6,4 @@
   command:
     cmd: 'service auditd restart'  # rhel: see: https://access.redhat.com/solutions/2664811
     warn: false  # sadly 'service' module fails in that case also by using 'use: service'
-  tags:
-    - molecule-notest  # restarting auditd in a container does not work
+  when: molecule_yml is not defined  # restarting auditd in a container does not work

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -6,3 +6,5 @@
   command:
     cmd: 'service auditd restart'  # rhel: see: https://access.redhat.com/solutions/2664811
     warn: false  # sadly 'service' module fails in that case also by using 'use: service'
+  tags:
+    - molecule-notest  # restarting auditd in a container does not work

--- a/roles/os_hardening/tasks/auditd.yml
+++ b/roles/os_hardening/tasks/auditd.yml
@@ -3,6 +3,7 @@
   package:
     name: '{{ auditd_package }}'
     state: 'present'
+  tags: auditd
 
 - name: configure auditd | package-08
   template:
@@ -11,3 +12,5 @@
     owner: 'root'
     group: 'root'
     mode: '0640'
+  notify: 'restart-auditd'
+  tags: auditd


### PR DESCRIPTION
 (e.g. of os_auditd_max_log_file_action) you need to restart. Sadly on rhel7 systems you cannot use systemd. And as debian derivates use service as alias and it works I kept it that simple. also adding 'auditd'-tag to make it easy only run that config change if needed.

Signed-off-by: Felix Herzog <snoopotic@gmail.com>


This is a copy of PR https://github.com/dev-sec/ansible-collection-hardening/pull/260, because the other one was too hard to rebase.