### PR TITLE
Use pam_pwhistory.so instead of pam_unix.so for remembering old passwords

### DIFF
--- a/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
+++ b/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
@@ -33,11 +33,12 @@ account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required      pam_permit.so
 
 {% if (os_auth_pam_passwdqc_enable | bool) %}
-password    required      pam_pwquality.so {{ os_auth_pam_pwquality_options }}
+password    requisite     pam_pwquality.so {{ os_auth_pam_pwquality_options }}
 {% endif %}
-# NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512
-# NSA 2.3.3.6 Limit Password Reuse
-password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok remember=5
+{# NSA 2.3.3.6 Limit Password Reuse #}
+password    required      pam_pwhistory.so remember=5 use_authtok
+{# NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512 #}
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 {% if (os_auth_pam_sssd_enable | bool) %}
 password    sufficient    pam_sss.so use_authtok
 {% endif %}

--- a/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
+++ b/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
@@ -36,7 +36,7 @@ account     required      pam_permit.so
 password    requisite     pam_pwquality.so {{ os_auth_pam_pwquality_options }}
 {% endif %}
 {# NSA 2.3.3.6 Limit Password Reuse #}
-password    required      pam_pwhistory.so remember=5 use_authtok
+password    requisite     pam_pwhistory.so remember=5 use_authtok
 {# NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512 #}
 password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
 {% if (os_auth_pam_sssd_enable | bool) %}


### PR DESCRIPTION
Having `pam_unix.so remember=5` gives a bug that makes it impossible to change password.
You get "login cannot read /etc/security/opasswd" in /var/log/secure.
I think this is a bug report about it, at least I had the same symptoms:
https://bugs.centos.org/view.php?id=13211

The manual for `pam_unix.se`states that `remember=n`should not be used there anymore:

>  Instead of this option the pam_pwhistory module should be used.
http://www.linux-pam.org/Linux-PAM-html/sag-pam_unix.html

https://access.redhat.com/solutions/2808101


I also changed required -> requisite for `pam_pwquality.so`. I think it makes more sense.

I have tested this with CentOS7 and 8.

And you can close PR https://github.com/dev-sec/ansible-collection-hardening/pull/430 since the comments are "fixed" here as well.

Signed-off-by: Farid Joubbi <farid@joubbi.se>