### PR TITLE
os_auth_pam_pwquality_options: Changed type to authtok_type

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -9,7 +9,7 @@ os_auth_timeout: 60
 os_auth_allow_homeless: false
 os_auth_pam_passwdqc_enable: true
 os_auth_pam_passwdqc_options: 'min=disabled,disabled,16,12,8'  # used in RHEL6
-os_auth_pam_pwquality_options: 'try_first_pass retry=3 type='  # used in RHEL7
+os_auth_pam_pwquality_options: 'try_first_pass retry=3 authtok_type='  # used in RHEL7
 os_auth_root_ttys: [console, tty1, tty2, tty3, tty4, tty5, tty6]
 
 os_chfn_restrict: ''


### PR DESCRIPTION
I couldn't find any reliable documentation about `type=`.
I could find about `authtok_type=`.
For example here: https://linux.die.net/man/8/pam_pwquality and
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/system-level_authentication_guide/index

Both `type=foobar` and `authtok_type=foobar` changes the password prompt the same way.
So I don't know if there is a difference, but since most documentation says `authtok_type=`...

The default for RHEL7/8 is to have an empty type. So the `authtok_type=`is not actually needed.
It could be removed completely and maybe it should, for less confusion. 

Signed-off-by: Farid Joubbi <farid@joubbi.se>