### PR TITLE
mysql_version.version.full does not exist when mysql_distribution == "mariadb"

### DIFF
--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -41,8 +41,8 @@
   set_fact:
     mysql_hardening_options: "{{ mysql_hardening_options| dict2items | rejectattr('key', 'search', 'secure-auth') | list | items2dict }}"
   when:
-    - mysql_version.version.full is version('8.0.3', '>=')
     - mysql_distribution == "mysql"
+    - mysql_version.version.full is version('8.0.3', '>=')
 
 - include: configure.yml
   when: mysql_hardening_enabled | bool

--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -59,6 +59,7 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_users_wo_passwords_or_auth_string
   when:
+    - mysql_distribution == "mysql"
     - mysql_version.version.full is version('5.7.6', '>=')
 
 - name: get all users that have no password on MySQL version < 5.7.6
@@ -76,6 +77,7 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_users_wo_passwords
   when:
+    - mysql_distribution == "mysql"
     - mysql_version.version.full is version('5.7.6', '<')
 
 - name: create a fact for users without password or authentication_string


### PR DESCRIPTION
For tasks which are specific to a 'MySQL' distribution (using when-condition on 'mysql_version.version.full') :
- Added when-condition on mysql_distribution == "mysql"
- Problem with short-circuit evaluation : first check on mysql_distribution, then on mysql_version.version.full