### PR TITLE
ssh: Client HostKeyAlgorithms configuration variable

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -41,6 +41,9 @@ Warning: This role disables root-login on the target server! Please make sure yo
 - `ssh_host_key_algorithms`
   - Default: `[]`
   - Description: Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms.
+- `ssh_client_host_key_algorithms`
+  - Default: `[]`
+  - Description: Specifies the host key algorithms that the client wants to use in order of preference. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man ssh_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version!.
 - `ssh_client_alive_interval`
   - Default: `600`
   - Description: specifies an interval for sending keepalive messages.

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -40,7 +40,7 @@ Warning: This role disables root-login on the target server! Please make sure yo
   - Description: Specifies the number of bits in the private host RSA key to create.
 - `ssh_host_key_algorithms`
   - Default: `[]`
-  - Description: Host key algorithms that the server offers. If empty the [default list](https://man.openbsd.org/sshd_config#HostKeyAlgorithms) will be used, otherwise overrides the setting with specified list of algorithms.
+  - Description: Host key algorithms that the server offers. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man sshd_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version!
 - `ssh_client_host_key_algorithms`
   - Default: `[]`
   - Description: Specifies the host key algorithms that the client wants to use in order of preference. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man ssh_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version!.

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -45,6 +45,9 @@ ssh_host_certificates: []           # sshd
 # Specifies the host key algorithms that the server offers
 ssh_host_key_algorithms: []         # sshd
 
+# Specifies the host key algorithms order the client will try
+ssh_client_host_key_algorithms: []  # ssh
+
 # specifies the time allowed for successful authentication to the SSH server
 ssh_login_grace_time: 30s
 

--- a/roles/ssh_hardening/templates/openssh.conf.j2
+++ b/roles/ssh_hardening/templates/openssh.conf.j2
@@ -81,6 +81,9 @@ StrictHostKeyChecking ask
 {# This outputs 'KexAlgorithms <list-of-algos>' if ssh_kex is defined or '#KexAlgorithms' if ssh_kex is undefined #}
 {{ 'KexAlgorithms ' ~ ssh_kex|join(',') if ssh_kex else 'KexAlgorithms'|comment }}
 
+# Specifies the host key algorithms that the client wants to use in order of preference.
+{{ "HostKeyAlgorithms " ~ ssh_client_host_key_algorithms|join(',') if ssh_client_host_key_algorithms else "HostKeyAlgorithms"|comment }}
+
 {% if sshd_version is version('5.9', '<') %}
 # Alternative setting, if OpenSSH version is below v5.9
 #MACs hmac-ripemd160


### PR DESCRIPTION
Introduce a new variable ssh_client_host_key_algorithms to be able to configure
it for the client like for the server.
This fixes #441