### PR TITLE
mysql USER and HOST should be quoted for drop query

### DIFF
--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -49,7 +49,7 @@
 - name: get all users that have no password or authentication_string on MySQL version >= 5.7.6
   community.mysql.mysql_query:
     query:
-      - SELECT GROUP_CONCAT(USER, '@', HOST SEPARATOR ', ') AS users
+      - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users
         FROM mysql.user
         WHERE (length(authentication_string)=0
               OR authentication_string="")
@@ -64,7 +64,7 @@
 - name: get all users that have no password on MySQL version < 5.7.6
   community.mysql.mysql_query:
     query:
-      - SELECT GROUP_CONCAT(USER, '@', HOST SEPARATOR ', ') AS users
+      - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users
         FROM mysql.user
         WHERE (length(password)=0
               OR password="")


### PR DESCRIPTION
USER and HOST should be quoted to avoid errors in drop user statement.

Query result unquoted:
```
+------------------------------------------+
| users                                    |
+------------------------------------------+
| root@localhost, root@127.0.0.1, root@::1 |
+------------------------------------------+

```
Raised this error:
```
TASK [devsec.hardening.mysql_hardening : ensure that there are no users without password or authentication_string] *************************************************************************
fatal: [host]: FAILED! => changed=false
  msg: 'Cannot execute SQL ''DROP USER root@localhost, root@127.0.0.1, root@::1'' args [None]: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''::1'' at line 1")'

```
Query result Quoted:
```
+------------------------------------------------------+
| users                                                |
+------------------------------------------------------+
| 'root'@'localhost', 'root'@'127.0.0.1', 'root'@'::1' |
+------------------------------------------------------+
```