### PR TITLE
Check for MariaDB Version when selecting users without passwords

### DIFF
--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -62,7 +62,7 @@
     - (mysql_distribution == "mysql" and mysql_version.version.full is version('5.7.6', '>=')) or
       (mysql_distribution == "mariadb" and mysql_version.version.full is version('10.4.0', '>='))
 
-- name: get all users that have no password on MySQL version < 5.7.6 or Mariadb version < 10.4.0
+- name: get all users that have no password or authentication_string on MySQL version < 5.7.6 or Mariadb version < 10.4.0
   community.mysql.mysql_query:
     query:
       - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users

--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -46,7 +46,7 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   when: mysql_remove_remote_root
 
-- name: get all users that have no password or authentication_string on MySQL version >= 5.7.6
+- name: get all users that have no password or authentication_string on MySQL version >= 5.7.6 or Mariadb version >= 10.4.0
   community.mysql.mysql_query:
     query:
       - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users
@@ -59,9 +59,10 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_users_wo_passwords_or_auth_string
   when:
-    - mysql_version.version.full is version('5.7.6', '>=')
+    - (mysql_distribution == "mysql" and mysql_version.version.full is version('5.7.6', '>=')) or
+      (mysql_distribution == "mariadb" and mysql_version.version.full is version('10.4.0', '>='))
 
-- name: get all users that have no password on MySQL version < 5.7.6
+- name: get all users that have no password on MySQL version < 5.7.6 or Mariadb version < 10.4.0
   community.mysql.mysql_query:
     query:
       - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users
@@ -76,7 +77,8 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_users_wo_passwords
   when:
-    - mysql_version.version.full is version('5.7.6', '<')
+    - (mysql_distribution == "mysql" and mysql_version.version.full is version('5.7.6', '<')) or
+      (mysql_distribution == "mariadb" and mysql_version.version.full is version('10.4.0', '<'))
 
 - name: create a fact for users without password or authentication_string
   set_fact:

--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -46,7 +46,7 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   when: mysql_remove_remote_root
 
-- name: get all users that have no password or authentication_string on MySQL version >= 5.7.6 or Mariadb version >= 10.4.0
+- name: get all users that have no authentication_string on MySQL version >= 5.7.6 or Mariadb version >= 10.4.0
   community.mysql.mysql_query:
     query:
       - SELECT GROUP_CONCAT(QUOTE(USER), '@', QUOTE(HOST) SEPARATOR ', ') AS users


### PR DESCRIPTION
MariaDB uses the authentication_string field since 10.4.0, added this in version check in query for users to delete.

https://mariadb.com/kb/en/authentication-from-mariadb-104/

Without these changes, the role assumes 10.3 >= 5.7.6 and drops all users with empty authentication_string. Since authentication_string is not used in this versions (Password field is used, authentication_string is always empty), the role simply drops all users.