### PR TITLE
Use `include_tasks` for os_hardening/main.yml

### DIFF
--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -14,7 +14,7 @@
 
 # we only override variables with our default, if they have not been specified already
 # by default the lookup functions finds all varnames containing the string, therefore
-# we add ^ and $ to denote start and end of string, so this returns only exact maches
+# we add ^ and $ to denote start and end of string, so this returns only exact matches
 - name: Set OS dependent variables, if not already defined by user
   set_fact:
     '{{ item.key }}': '{{ item.value }}'

--- a/roles/os_hardening/tasks/main.yml
+++ b/roles/os_hardening/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- import_tasks: hardening.yml
+- include_tasks: hardening.yml
   when: os_hardening_enabled | bool


### PR DESCRIPTION
When `import_tasks` is used, the task `Fetch OS dependent variables`
always runs, even when excluded by an upstream tag.

When `Fetch OS dependent variables` runs while excluded via tags, it
will always fail with the following.

```
fatal: [alpha]: FAILED! => {"msg": "No file was found when using first_found. Use errors='ignore' to allow this task to be skipped if no files are found"}
```

This brings os_hardening's main.yml in line with ssh_hardening's
main.yml, which doesn't have this issue.