### PR TITLE
add tag always to os dependent vars task

### DIFF
--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -20,6 +20,7 @@
     '{{ item.key }}': '{{ item.value }}'
   when: "not lookup('varnames', '^' + item.key + '$')"
   with_dict: '{{ os_vars }}'
+  tags: always
 
 - name: Gather package facts to check for mysql/mariadb version
   ansible.builtin.package_facts:

--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -20,6 +20,7 @@
     '{{ item.key }}': '{{ item.value }}'
   when: "not lookup('varnames', '^' + item.key + '$')"
   with_dict: '{{ os_vars }}'
+  tags: always
 
 - import_tasks: auditd.yml
   tags: auditd

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -20,6 +20,7 @@
     '{{ item.key }}': '{{ item.value }}'
   when: "not lookup('varnames', '^' + item.key + '$')"
   with_dict: '{{ os_vars }}'
+  tags: always
 
 - name: Get openssh-version
   command: ssh -V


### PR DESCRIPTION
when our collection is used with tags, the os dependent variables are
not resolved. This task should run every time, so the behaviour is
correct.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>