### PR TITLE
Add os_auth_uid_max, os_auth_gid_max

### DIFF
--- a/roles/os_hardening/templates/etc/login.defs.j2
+++ b/roles/os_hardening/templates/etc/login.defs.j2
@@ -114,14 +114,14 @@ PASS_WARN_AGE     7
 
 # Min/max values for automatic uid selection in useradd
 UID_MIN           {{ os_auth_uid_min }}
-UID_MAX           60000
+UID_MAX           {{ os_auth_uid_max }}
 # System accounts
 SYS_UID_MIN       {{ os_auth_sys_uid_min }}
 SYS_UID_MAX       {{ os_auth_sys_uid_max }}
 
 # Min/max values for automatic gid selection in groupadd
 GID_MIN           {{ os_auth_gid_min }}
-GID_MAX           60000
+GID_MAX           {{ os_auth_gid_max }}
 # System accounts
 SYS_GID_MIN       {{ os_auth_sys_gid_min }}
 SYS_GID_MAX       {{ os_auth_sys_gid_max }}

--- a/roles/os_hardening/vars/Amazon.yml
+++ b/roles/os_hardening/vars/Amazon.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '077'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/Archlinux.yml
+++ b/roles/os_hardening/vars/Archlinux.yml
@@ -15,7 +15,9 @@ os_passwd_perms:
 os_env_umask: '027'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 500
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 500

--- a/roles/os_hardening/vars/Debian.yml
+++ b/roles/os_hardening/vars/Debian.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '027'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 100
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 100

--- a/roles/os_hardening/vars/Fedora.yml
+++ b/roles/os_hardening/vars/Fedora.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '027'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/RedHat.yml
+++ b/roles/os_hardening/vars/RedHat.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '077'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/RedHat_7.yml
+++ b/roles/os_hardening/vars/RedHat_7.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '077'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/RedHat_8.yml
+++ b/roles/os_hardening/vars/RedHat_8.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '077'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/Rocky_8.yml
+++ b/roles/os_hardening/vars/Rocky_8.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '077'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201

--- a/roles/os_hardening/vars/Suse.yml
+++ b/roles/os_hardening/vars/Suse.yml
@@ -19,7 +19,9 @@ os_passwd_perms:
 os_env_umask: '027'
 
 os_auth_uid_min: 1000
+os_auth_uid_max: 60000
 os_auth_gid_min: 1000
+os_auth_gid_max: 60000
 os_auth_sys_uid_min: 100
 os_auth_sys_uid_max: 499
 os_auth_sys_gid_min: 100


### PR DESCRIPTION
Add support for `os_auth_uid_max`, `os_auth_gid_max`

I have a use case when uid matches an internal big number so the range goes beyond 60000.