### PR TITLE
Add SUB_UID_MIN/MAX/COUNT, SUB_GID_MIN/MAX/COUNT

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -148,6 +148,36 @@ We know that this is the case on Raspberry Pi.
 - `os_security_suid_sgid_remove_from_unknown`
   - Default: `false`
   - Description: true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Ansible-run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
+- `os_auth_uid_min`
+  - Default: `1000`
+  - Description: minimum number for automatic uid selection in useradd.
+- `os_auth_uid_max`
+  - Default: `60000`
+  - Description: maximum number for automatic uid selection in useradd.
+- `os_auth_gid_min`
+  - Default: `1000`
+  - Description: minimum number for automatic gid selection in groupadd.
+- `os_auth_gid_max`
+  - Default: `60000`
+  - Description: maximum number for automatic gid selection in groupadd.
+- `os_auth_sub_uid_count`
+  - Default: `65536`
+  - Description: If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate user IDs) allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user. See also `os_auth_sub_uid_min` and `os_auth_sub_uid_max`.
+- `os_auth_sub_uid_min`.
+  - Default: `100000`
+  - Description: minimum number for automatic subordinate uid selection in useradd and newusers.
+- `os_auth_sub_uid_max`
+  - Default: `600100000`
+  - Description: maximum number for automatic subordinate uid selection in useradd and newusers.
+- `os_auth_sub_gid_count`
+  - Default: `65536`
+  - Description: If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate group IDs) allocate SUB_GID_COUNT unused group IDs from the range SUB_GID_MIN to SUB_GID_MAX for each new user. See also `os_auth_sub_gid_min` and `os_auth_sub_gid_max`.
+- `os_auth_sub_gid_min`
+  - Default: `100000`
+  - Description: minimum number for automatic subordinate gid selection in useradd and newusers.
+- `os_auth_sub_gid_max`
+  - Default: `600100000`
+  - Description: maximum number for automatic subordinate gid selection in useradd and newusers.
 - `os_security_packages_clean`
   - Default: `true`
   - Description: removes packages with known issues. See section packages.

--- a/roles/os_hardening/templates/etc/login.defs.j2
+++ b/roles/os_hardening/templates/etc/login.defs.j2
@@ -126,6 +126,16 @@ GID_MAX           {{ os_auth_gid_max }}
 SYS_GID_MIN       {{ os_auth_sys_gid_min }}
 SYS_GID_MAX       {{ os_auth_sys_gid_max }}
 
+# If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate user IDs)
+# allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user.
+# The default values for SUB_UID_MIN, SUB_UID_MAX, SUB_UID_COUNT are respectively 100000, 600100000 and 65536.
+SUB_UID_MIN       {{ os_auth_sub_uid_min }}
+SUB_UID_MAX       {{ os_auth_sub_uid_max }}
+SUB_UID_COUNT     {{ os_auth_sub_uid_count }}
+SUB_GID_MIN       {{ os_auth_sub_gid_min }}
+SUB_GID_MAX       {{ os_auth_sub_gid_max }}
+SUB_GID_COUNT     {{ os_auth_sub_gid_count }}
+
 # Max number of login retries if password is bad. This will most likely be overriden by PAM, since the default pam_unix module has it's own built in of 3 retries. However, this is a safe fallback in case you are using an authentication module that does not enforce PAM_MAXTRIES.
 LOGIN_RETRIES     {{ os_auth_retries }}
 

--- a/roles/os_hardening/vars/Amazon.yml
+++ b/roles/os_hardening/vars/Amazon.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: false
 

--- a/roles/os_hardening/vars/Archlinux.yml
+++ b/roles/os_hardening/vars/Archlinux.yml
@@ -22,6 +22,12 @@ os_auth_sys_uid_min: 500
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 500
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 modprobe_package: 'kmod'
 auditd_package: 'audit'

--- a/roles/os_hardening/vars/Debian.yml
+++ b/roles/os_hardening/vars/Debian.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 100
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 # defaults for useradd
 os_useradd_mail_dir: /var/mail

--- a/roles/os_hardening/vars/Fedora.yml
+++ b/roles/os_hardening/vars/Fedora.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: true
 

--- a/roles/os_hardening/vars/RedHat.yml
+++ b/roles/os_hardening/vars/RedHat.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: false
 

--- a/roles/os_hardening/vars/RedHat_7.yml
+++ b/roles/os_hardening/vars/RedHat_7.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: false
 

--- a/roles/os_hardening/vars/RedHat_8.yml
+++ b/roles/os_hardening/vars/RedHat_8.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: true
 

--- a/roles/os_hardening/vars/Rocky_8.yml
+++ b/roles/os_hardening/vars/Rocky_8.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 201
 os_auth_sys_uid_max: 999
 os_auth_sys_gid_min: 201
 os_auth_sys_gid_max: 999
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 os_auth_pam_sssd_enable: true
 

--- a/roles/os_hardening/vars/Suse.yml
+++ b/roles/os_hardening/vars/Suse.yml
@@ -26,6 +26,12 @@ os_auth_sys_uid_min: 100
 os_auth_sys_uid_max: 499
 os_auth_sys_gid_min: 100
 os_auth_sys_gid_max: 499
+os_auth_sub_uid_min: 100000
+os_auth_sub_uid_max: 600100000
+os_auth_sub_uid_count: 65536
+os_auth_sub_gid_min: 100000
+os_auth_sub_gid_max: 600100000
+os_auth_sub_gid_count: 65536
 
 # defaults for useradd
 os_useradd_create_home: false


### PR DESCRIPTION
Similar reason as #461

> If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate user IDs)
> allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user.
> The default values for SUB_UID_MIN, SUB_UID_MAX, SUB_UID_COUNT are respectively 100000, 600100000 and 65536.
