### PR TITLE
Allow configuration of password remember in pam

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -107,7 +107,7 @@ We know that this is the case on Raspberry Pi.
   - Default: `7`
   - Description: minimum password age (before allowing any other password change).
 - `os_auth_pw_remember`
-  - Default: `60`
+  - Default: `5`
   - Description: how many used passwords are record.
 - `os_auth_retries`
   - Default: `5`

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -106,6 +106,9 @@ We know that this is the case on Raspberry Pi.
 - `os_auth_pw_min_age`
   - Default: `7`
   - Description: minimum password age (before allowing any other password change).
+- `os_auth_pw_remember`
+  - Default: `60`
+  - Description: how many used passwords are record.
 - `os_auth_retries`
   - Default: `5`
   - Description: the maximum number of authentication attempts, before the account is locked for some time.

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -3,7 +3,7 @@ os_desktop_enable: false
 os_env_extra_user_paths: []
 os_auth_pw_max_age: 60
 os_auth_pw_min_age: 7  # Discourage password cycling
-os_auth_pw_remember: 60  # Specify how many used passwords are record
+os_auth_pw_remember: 5  # Specify how many used passwords are record
 os_auth_retries: 5
 os_auth_lockout_time: 600  # Seconds (600 = 10min)
 os_auth_timeout: 60

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -3,6 +3,7 @@ os_desktop_enable: false
 os_env_extra_user_paths: []
 os_auth_pw_max_age: 60
 os_auth_pw_min_age: 7  # Discourage password cycling
+os_auth_pw_remember: 60  # Specify how many used passwords are record
 os_auth_retries: 5
 os_auth_lockout_time: 600  # Seconds (600 = 10min)
 os_auth_timeout: 60

--- a/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
+++ b/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
@@ -36,7 +36,7 @@ account     required      pam_permit.so
 password    requisite     pam_pwquality.so {{ os_auth_pam_pwquality_options }}
 {% endif %}
 {# NSA 2.3.3.6 Limit Password Reuse #}
-password    requisite     pam_pwhistory.so remember=5 use_authtok
+password    requisite     pam_pwhistory.so remember={{ os_auth_pw_remember }} use_authtok
 {# NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512 #}
 password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok rounds={{ os_sha_crypt_min_rounds }}
 {% if (os_auth_pam_sssd_enable | bool) %}


### PR DESCRIPTION
and set default to 60

see Telekom 2021.07-01 SoC 3.01 Req 25 and SoC 3.65 Req46
Public [Telekom Security - Requirements](https://www.telekom.com/resource/blob/327540/0af4a73d01334926f71d5530a2c2477e/dl-security-requirements-data.zip)