### PR TITLE
[mysql_hardening] Allow setting the mysql_distribution

### DIFF
--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -22,13 +22,20 @@
   with_dict: '{{ os_vars }}'
   tags: always
 
+- ansible.builtin.assert:
+    that: mysql_distribution == 'mysql' or mysql_distribution == 'mariadb'
+    fail_msg: 'mysql_distribution must be set to either mysql or mariadb!'
+  when: mysql_distribution is defined
+
 - name: Gather package facts to check for mysql/mariadb version
   ansible.builtin.package_facts:
     manager: auto
+  when: not mysql_distribution is defined
 
 - name: Check if MySQL or MariaDB is used
   set_fact:
     mysql_distribution: "{{ ansible_facts.packages['mysql-server'] is defined | ternary('mysql', 'mariadb') }}"
+  when: not mysql_distribution is defined
 
 - name: Check which MySQL/MariaDB version is used
   community.mysql.mysql_info:

--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -22,7 +22,8 @@
   with_dict: '{{ os_vars }}'
   tags: always
 
-- ansible.builtin.assert:
+- name: Check that the variable mysql_distribution is set correctly
+  ansible.builtin.assert:
     that: mysql_distribution == 'mysql' or mysql_distribution == 'mariadb'
     fail_msg: 'mysql_distribution must be set to either mysql or mariadb!'
   when: mysql_distribution is defined


### PR DESCRIPTION
On some operating systems, the package for MySQL is not `mysql-server`,
and so the default check for this will not yield the correct result.
This change adds an escape hatch by letting the user set
`mysql_distribution`.  Additionally, it verifies that it is set to a
legal value if the user has set it.

Closes #472