### PR TITLE
Execute check of MySQL error logfile permissions on Debian 11 only when log_error is defined

### DIFF
--- a/roles/mysql_hardening/tasks/configure.yml
+++ b/roles/mysql_hardening/tasks/configure.yml
@@ -23,6 +23,7 @@
     owner: '{{ mysql_hardening_user }}'
     group: '{{ mysql_hardening_group }}'
     mode: '0640'
+  when: mysql_settings.settings.log_error != ""
 
 - name: Check mysql configuration-directory exists and has right permissions
   file:

--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -44,6 +44,12 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_version
 
+- name: Check MySQL/MariaDB settings
+  community.mysql.mysql_info:
+    filter: settings
+    login_unix_socket: "{{ login_unix_socket | default(omit) }}"
+  register: mysql_settings
+
 # see https://stackoverflow.com/a/59451077/2953919 for the
 # dict2items and vice versa magic
 - name: Drop the secure-auth parameter on MySQL >=8.0.3 (not mariadb)


### PR DESCRIPTION
This PR fixes checking of log_error file permissions from MariaDB on Debian 11.

If no log_file is defined, then logs goes to systemd and not to the log file. So skip checking permissions of the log_error file if no log_error file is defined on Debian 11.

Fixes #476