### PR TITLE
Use `log_error` file and `datadir` from mysql_info settings instead of variables `mysql_datadir` and `mysql_hardening_log_file`

### DIFF
--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -27,12 +27,14 @@ It configures:
     - mysql_hardening
 ```
 
-This role expects an existing installation of MySQL or MariaDB. Please ensure that the following variables are set accordingly:
+This role expects an existing installation of MySQL or MariaDB.  Changes of options `log_error` or `datadir` in `mysql_hardening_options` will not be checked for correct permissions. Please change/set `log_error` or `datadir` with the installation role of MySQL before running this role, or you can run this role twice.  
+Please ensure that the following variables are set accordingly:
 
 - `mysql_hardening_enabled: yes` role is enabled by default and can be disabled without removing it from a playbook. You can use conditional variable, for example: `mysql_hardening_enabled: "{{ true if mysql_enabled else false }}"`
 - `mysql_hardening_user: 'mysql'` The user that mysql runs as.
-- `mysql_datadir: '/var/lib/mysql'` The MySQL data directory
 - `mysql_hardening_mysql_hardening_conf_file: '/etc/mysql/conf.d/hardening.cnf'` The path to the configuration file where the hardening will be performed
+- _deprecated: `mysql_datadir: '/var/lib/mysql'` The MySQL data directory_
+  - `mysql_datadir` is no longer necessary, as MySQL data directory is automatically taken from `mysql_info`. But it can still be defined and will also be checked for correct permissions.
 
 ## Role Variables
 

--- a/roles/mysql_hardening/defaults/main.yml
+++ b/roles/mysql_hardening/defaults/main.yml
@@ -7,7 +7,6 @@ mysql_daemon_enabled: true
 mysql_hardening_restart_mysql: true
 
 # general configuration
-mysql_datadir: '/var/lib/mysql'
 mysql_hardening_mysql_hardening_conf_file: '{{mysql_hardening_mysql_confd_dir}}/hardening.cnf'
 # You have to change this to your own strong enough mysql root password
 mysql_root_password: '-----====>SetR00tPa$$wordH3r3!!!<====-----'

--- a/roles/mysql_hardening/tasks/configure.yml
+++ b/roles/mysql_hardening/tasks/configure.yml
@@ -10,20 +10,27 @@
 
 - name: Ensure permissions on mysql-datadir are correct
   file:
-    path: '{{ mysql_datadir }}'
+    path: '{{ item }}'
     state: directory
     owner: '{{ mysql_hardening_user }}'
     group: '{{ mysql_hardening_user }}'
     mode: '0750'
+  when: item is defined and item != ""
+  loop:
+    - '{{ mysql_settings.settings.datadir }}'
+    - '{{ mysql_datadir|default("") }}'
 
 - name: Ensure permissions on mysql-logfile are correct
   file:
-    path: '{{ mysql_hardening_log_file }}'
+    path: '{{ item }}'
     state: file
     owner: '{{ mysql_hardening_user }}'
     group: '{{ mysql_hardening_group }}'
     mode: '0640'
-  when: mysql_settings.settings.log_error != ""
+  when: item is defined and item != ""
+  loop:
+    - '{{ mysql_settings.settings.log_error }}'
+    - '{{ mysql_hardening_log_file|default("") }}'
 
 - name: Check mysql configuration-directory exists and has right permissions
   file:

--- a/roles/mysql_hardening/vars/Debian.yml
+++ b/roles/mysql_hardening/vars/Debian.yml
@@ -4,8 +4,6 @@ mysql_daemon: mysql
 mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/mysql/conf.d'
 
-mysql_hardening_log_file: '/var/log/mysql/error.log'
-
 mysql_hardening_group: 'adm'
 
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files

--- a/roles/mysql_hardening/vars/Fedora.yml
+++ b/roles/mysql_hardening/vars/Fedora.yml
@@ -2,5 +2,3 @@
 mysql_daemon: mysqld
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
-
-mysql_hardening_mysql_log_file: '/var/log/mysqld.log'

--- a/roles/mysql_hardening/vars/FreeBSD.yml
+++ b/roles/mysql_hardening/vars/FreeBSD.yml
@@ -4,8 +4,6 @@ mysql_daemon: mysql-server
 mysql_hardening_mysql_conf_file: '/usr/local/etc/mysql/my.cnf'
 mysql_hardening_mysql_confd_dir: '/usr/local/etc/mysql/conf.d'
 
-mysql_hardening_log_file: '/var/db/mysql/mysql.err'
-
 mysql_hardening_group: 'mysql'
 
 mysql_cnf_owner: 'root'  # owner of /usr/local/etc/mysql/*.cnf files

--- a/roles/mysql_hardening/vars/Oracle Linux.yml
+++ b/roles/mysql_hardening/vars/Oracle Linux.yml
@@ -4,6 +4,4 @@ mysql_daemon: mysqld
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
 
-mysql_hardening_log_file: '/var/log/mysqld.log'
-
 mysql_hardening_group: 'adm'

--- a/roles/mysql_hardening/vars/RedHat_7.yml
+++ b/roles/mysql_hardening/vars/RedHat_7.yml
@@ -3,8 +3,6 @@ mysql_daemon: mariadb
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
 
-mysql_hardening_log_file: '/var/log/mariadb/mariadb.log'
-
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files
 

--- a/roles/mysql_hardening/vars/RedHat_8.yml
+++ b/roles/mysql_hardening/vars/RedHat_8.yml
@@ -2,7 +2,6 @@
 mysql_daemon: mariadb
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
-mysql_hardening_log_file: '/var/log/mariadb/mariadb.log'
 
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files

--- a/roles/mysql_hardening/vars/Rocky_8.yml
+++ b/roles/mysql_hardening/vars/Rocky_8.yml
@@ -2,7 +2,6 @@
 mysql_daemon: mariadb
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
-mysql_hardening_log_file: '/var/log/mariadb/mariadb.log'
 
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files

--- a/roles/mysql_hardening/vars/Ubuntu_16.yml
+++ b/roles/mysql_hardening/vars/Ubuntu_16.yml
@@ -4,8 +4,6 @@ mysql_daemon: mysql
 mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/mysql/conf.d'
 
-mysql_hardening_log_file: '/var/log/mysql/error.log'
-
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files
 

--- a/roles/mysql_hardening/vars/Ubuntu_18.yml
+++ b/roles/mysql_hardening/vars/Ubuntu_18.yml
@@ -4,8 +4,6 @@ mysql_daemon: mysql
 mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/mysql/conf.d'
 
-mysql_hardening_log_file: '/var/log/mysql/error.log'
-
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files
 

--- a/roles/mysql_hardening/vars/Ubuntu_20.yml
+++ b/roles/mysql_hardening/vars/Ubuntu_20.yml
@@ -4,8 +4,6 @@ mysql_daemon: mysql
 mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
 mysql_hardening_mysql_confd_dir: '/etc/mysql/conf.d'
 
-mysql_hardening_log_file: '/var/log/mysql/error.log'
-
 mysql_cnf_owner: 'root'  # owner of /etc/mysql/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/mysql/*.cnf files
 


### PR DESCRIPTION
As discussed in PR #477, this PR changes the handling with the log_error file.
The log_error file from mysql_info `mysql_settings.settings.log_error` is used instead of default variable `mysql_hardening_log_file`.  


As drawback, when changing `log_error` option using `mysql_hardening_options`, this new file will not be checked, as the configuration in `mysql_hardening_mysql_hardening_conf_file` happens after checking the permissions of the log_error file (but this also was the case when using the default variable).  
So when changing the setting `log_error` this must be done before running mysql-hardening or run mysql-hardening twice.
