### PR TITLE
feat(os_hardening): extend file permission tasks to cover more files

### DIFF
--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -27,19 +27,43 @@
     - "{{ minimize_access_directories.results }}"
     - stdout_lines
 
+- name: Find shadow files
+  stat:
+    path: "{{ item }}"
+  loop:
+    - '/etc/shadow'
+    - '/etc/gshadow'
+    - '/etc/shadow-'
+    - '/etc/gshadow-'
+  register: minimize_access_shadow_files
+
 - name: Change shadow ownership to root and mode to 0600 | os-02
   file:
-    dest: '/etc/shadow'
+    dest: "{{ item.item }}"
     owner: '{{ os_shadow_perms.owner }}'
     group: '{{ os_shadow_perms.group }}'
     mode: '{{ os_shadow_perms.mode }}'
+  when: item.stat.exists
+  loop: "{{ minimize_access_shadow_files.results }}"
+
+- name: Find passwd files
+  stat:
+    path: "{{ item }}"
+  loop:
+    - '/etc/passwd'
+    - '/etc/group'
+    - '/etc/passwd-'
+    - '/etc/group-'
+  register: minimize_access_passwd_files
 
 - name: Change passwd ownership to root and mode to 0644 | os-03
   file:
-    dest: '/etc/passwd'
+    dest: "{{ item.item }}"
     owner: '{{ os_passwd_perms.owner }}'
     group: '{{ os_passwd_perms.group }}'
     mode: '{{ os_passwd_perms.mode }}'
+  when: item.stat.exists
+  loop: "{{ minimize_access_passwd_files.results }}"
 
 - name: Change su-binary to only be accessible to user and group root
   file:


### PR DESCRIPTION
The tasks `Change shadow ownership to root and mode to 0600` and `Change
passwd ownership to root and mode to 0644` only handle
`/etc/shadow` and `/etc/passwd` respectively. But there multiple
adjacent files that should be handled with these rules as well:

- `/etc/gshadow`
- `/etc/shadow-`
- `/etc/gshadow-`
- `/etc/group`
- `/etc/shadow-`
- `/etc/group-`

This change adds those files to the rules, so that permissions are
handled in the same way.

Closes: #488

Signed-off-by: Claudius Heine <ch@denx.de>