### PR TITLE
add old role names to tags in Galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,6 +17,11 @@ tags:
   - nginx
   - mysql
   - openssh
+  - ansible-apache-hardening
+  - mysql-hardening
+  - nginx-hardening
+  - os-hardening
+  - ssh-hardening
 dependencies:
   ansible.posix: '>=1.0.0'
   community.crypto: '>=1.0.0'


### PR DESCRIPTION
We deprecated our roles in Ansible Galaxy the deprecation link contains
a search keyword with the role name and our new collection should be
found, if someone clicks this link.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>