### PR TITLE
Improve testing: install packages on Arch Linux

### DIFF
--- a/molecule/os_hardening/prepare.yml
+++ b/molecule/os_hardening/prepare.yml
@@ -34,13 +34,13 @@
           - procps-ng
       when: ansible_facts.distribution == 'Fedora'
 
-    - name: install packages
+    - name: install required tools on Arch
       pacman:
         name:
-          - "awk"
+          - awk
         state: present
         update_cache: true
-      ignore_errors: true
+      when: ansible_facts.os_family == 'Archlinux'
 
     - name: install required tools on RHEL
       yum:

--- a/molecule/ssh_hardening/prepare.yml
+++ b/molecule/ssh_hardening/prepare.yml
@@ -52,14 +52,14 @@
           - "openssh"
       when: ansible_facts.os_family == 'Suse'
 
-    - name: install packages
+    - name: install required tools on Arch
       pacman:
         name:
-          - "openssh"
-          - "awk"
+          - openssh
+          - awk
         state: present
         update_cache: true
-      ignore_errors: true
+      when: ansible_facts.os_family == 'Archlinux'
 
     - name: created needed directory
       file:

--- a/molecule/ssh_hardening_custom_tests/prepare.yml
+++ b/molecule/ssh_hardening_custom_tests/prepare.yml
@@ -52,14 +52,14 @@
           - "openssh"
       when: ansible_facts.os_family == 'Suse'
 
-    - name: install packages
+    - name: install required tools on Arch
       pacman:
         name:
-          - "openssh"
-          - "awk"
+          - openssh
+          - awk
         state: present
         update_cache: true
-      ignore_errors: true
+      when: ansible_facts.os_family == 'Archlinux'
 
     - name: created needed directory
       file:


### PR DESCRIPTION
This prevents annoying task errors (even though they are ignored) when testing on non-Arch distributions.

Running the `prepare` command, this was always visible:
> fatal: [instance]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"pacman\" in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin"}