### PR TITLE
Update nginx_add_header README to match default

### DIFF
--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -61,8 +61,8 @@ It works with the following nginx-roles, including, but not limited to:
   - Default: `default 5`
   - Description: Sets the shared memory zone and the maximum allowed number of connections for a given key value.
 - [nginx_add_header][]
-  - Default: `[ "X-Frame-Options SAMEORIGIN", "X-Content-Type-Options nosniff", "X-XSS-Protection \"1; mode=block\"" ]`
-  - Description:Adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307.
+  - Default: `[ "X-Frame-Options SAMEORIGIN", "X-Content-Type-Options nosniff", "X-XSS-Protection \"1; mode=block\"", Content-Security-Policy \"script-src 'self'; object-src 'self'\" ]`
+  - Description: Adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307.
 - [nginx_ssl_protocols][]
   - Default: `TLSv1.2`
   - Description: Specifies the SSL protocol which should be used.


### PR DESCRIPTION
The current default also includes a `Content-Security-Policy` (https://github.com/dev-sec/ansible-collection-hardening/blob/b67a28bd09edb1f334e444318cbb180144f87cb4/roles/nginx_hardening/defaults/main.yml#L22), added to the README me here. 