### PR TITLE
change hidepid mount task state to mounted

### DIFF
--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -79,4 +79,4 @@
     src: proc
     fstype: proc
     opts: '{{ proc_mnt_options }}'
-    state: present
+    state: mounted


### PR DESCRIPTION
@schurzi PR this avoid the need to reboot machines after playbook application.