### PR TITLE
Change permissions of the tmout.sh file

### DIFF
--- a/roles/os_hardening/tasks/profile.yml
+++ b/roles/os_hardening/tasks/profile.yml
@@ -20,4 +20,4 @@
     dest: '/etc/profile.d/tmout.sh'
     owner: 'root'
     group: 'root'
-    mode: '0750'
+    mode: '0644'


### PR DESCRIPTION
For a non-root user to be able to read the TMOUT variable, the permission of the tmout.sh file must be 0644. 
It would be necessary to study if the change does not also apply to the file pinerolo_profile.sh