### PR TITLE
Added ability to set AuthorizedKeysCommand for use with IPA/IDM.

### DIFF
--- a/molecule/ssh_hardening_custom_tests/converge.yml
+++ b/molecule/ssh_hardening_custom_tests/converge.yml
@@ -41,6 +41,7 @@
     ssh_deny_users: 'foo bar'
     ssh_deny_groups: 'foo bar'
     ssh_authorized_keys_file: '/etc/ssh/authorized_keys/%u'
+    ssh_authorized_keys_command: '/bin/true'
     ssh_max_auth_retries: 10
     ssh_permit_root_login: "without-password"
     ssh_permit_tunnel: true

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -115,6 +115,12 @@ ssh_allow_groups: ''                # sshd
 # change default file that contains the public keys that can be used for user authentication.
 ssh_authorized_keys_file: ''        # sshd
 
+# if specified, this program will be used to look up the user's public keys that can be used for user authentication.
+ssh_authorized_keys_command: ''
+
+# specifies the user under whose account the AuthorizedKeysCommand is run.
+ssh_authorized_keys_command_user: 'nobody'
+
 # specifies the file containing trusted certificate authorities public keys used to sign user certificates.
 ssh_trusted_user_ca_keys_file: ''   # sshd
 

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -169,6 +169,11 @@ AllowGroups {{ ssh_allow_groups }}
 AuthorizedKeysFile {{ ssh_authorized_keys_file }}
 
 {% endif %}
+{% if ssh_authorized_keys_command %}
+AuthorizedKeysCommand {{ ssh_authorized_keys_command }}
+AuthorizedKeysCommandUser {{ ssh_authorized_keys_command_user }}
+
+{% endif %}
 {% if ssh_trusted_user_ca_keys_file %}
 TrustedUserCAKeys {{ ssh_trusted_user_ca_keys_file }}
 {% if ssh_authorized_principals_file %}


### PR DESCRIPTION
This adds the ability to set `AuthorizedKeysCommand` and `AuthorizedKeysCommandUser` in `sshd_config` which is useful when integrating with FreeIPA/IDM and using `/usr/bin/sss_ssh_authorizedkeys` to lookup SSH authorized keys.