### PR TITLE
Harden tmp

### DIFF
--- a/molecule/os_hardening/converge.yml
+++ b/molecule/os_hardening/converge.yml
@@ -28,6 +28,7 @@
     os_filesystem_whitelist: []
     os_ctrlaltdel_disabled: true
     os_yum_repo_file_whitelist: ['foo.repo']
+    tmp_mnt_enabled: false
     sysctl_config:
       net.ipv4.ip_forward: 0
       net.ipv6.conf.all.forwarding: 0

--- a/molecule/os_hardening/converge.yml
+++ b/molecule/os_hardening/converge.yml
@@ -28,7 +28,7 @@
     os_filesystem_whitelist: []
     os_ctrlaltdel_disabled: true
     os_yum_repo_file_whitelist: ['foo.repo']
-    tmp_mnt_enabled: false
+    os_tmp_mnt_enabled: false
     sysctl_config:
       net.ipv4.ip_forward: 0
       net.ipv6.conf.all.forwarding: 0

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -280,6 +280,21 @@ We know that this is the case on Raspberry Pi.
 - `os_sha_crypt_max_rounds`
   - Default: `640000`
   - Description: Define the number of maximum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range.
+- `tmp_dir_mode`
+  - Default: '1777'
+  - Description: Define directory permissions of /tmp.
+- `tmp_mnt_enabled`
+  - Default: 'false'
+  - Description: Set to true to mount local disks to /tmp. You have to configure variable tmp_mnt_src to work.
+- `tmp_mnt_src`
+  - Default: ""
+  - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with tmp_mnt_options.
+- `tmp_mnt_filesystem`
+  - Default: "ext4"
+  - Description: Filesystem information for /etc/fstab entry.
+- `tmp_mnt_options`
+  - Default: 'rw,nosuid,nodev,noexec,relatime'
+  - Description: Options for /etc/fstab entry to mount to /tmp.
 
 ## Packages
 

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -280,19 +280,19 @@ We know that this is the case on Raspberry Pi.
 - `os_sha_crypt_max_rounds`
   - Default: `640000`
   - Description: Define the number of maximum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range.
-- `tmp_dir_mode`
+- `os_tmp_dir_mode`
   - Default: '1777'
   - Description: Define directory permissions of /tmp.
-- `tmp_mnt_enabled`
+- `os_tmp_mnt_enabled`
   - Default: 'false'
-  - Description: Set to true to mount /tmp as a separate filesystem. You have to configure variable `tmp_mnt_src` or the mount will fail.
-- `tmp_mnt_src`
+  - Description: Set to true to mount /tmp as a separate filesystem. You have to configure variable `os_tmp_mnt_src` or the mount will fail.
+- `os_tmp_mnt_src`
   - Default: ""
-  - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with `tmp_mnt_options`.
-- `tmp_mnt_filesystem`
+  - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with `os_tmp_mnt_options`.
+- `os_tmp_mnt_filesystem`
   - Default: "ext4"
   - Description: Filesystem information for /etc/fstab entry.
-- `tmp_mnt_options`
+- `os_tmp_mnt_options`
   - Default: 'rw,nosuid,nodev,noexec,relatime'
   - Description: Options for /etc/fstab entry to mount to /tmp.
 

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -288,7 +288,7 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to mount local disks to /tmp. You have to configure variable tmp_mnt_src to work.
 - `tmp_mnt_src`
   - Default: ""
-  - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with tmp_mnt_options.
+  - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with `tmp_mnt_options`.
 - `tmp_mnt_filesystem`
   - Default: "ext4"
   - Description: Filesystem information for /etc/fstab entry.

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -285,7 +285,7 @@ We know that this is the case on Raspberry Pi.
   - Description: Define directory permissions of /tmp.
 - `tmp_mnt_enabled`
   - Default: 'false'
-  - Description: Set to true to mount local disks to /tmp. You have to configure variable tmp_mnt_src to work.
+  - Description: Set to true to mount /tmp as a separate filesystem. You have to configure variable `tmp_mnt_src` or the mount will fail.
 - `tmp_mnt_src`
   - Default: ""
   - Description: Source to mount /tmp. Manages /etc/fstab and does automatically remount with `tmp_mnt_options`.

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -393,15 +393,15 @@ os_sha_crypt_max_rounds: "640000"
 
 # Define /tmp is a mountpoint.
 # If it is not, harden /tmp folder permissions
-tmp_mount_enabled: false
+tmp_mnt_enabled: false
 
 # Define source mountpoint for folder /tmp
 # example: /dev/vg_system/lv_tmp
-tmp_mount_source: ""
+tmp_mnt_source: ""
 
 # Define filesystem for tmp mount
 # default: ext4
-tmp_mount_filesystem: "ext4"
+tmp_mnt_filesystem: "ext4"
 
 # Mount options for /tmp in /etc/fstab.
 tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -392,20 +392,20 @@ os_sha_crypt_min_rounds: "640000"
 os_sha_crypt_max_rounds: "640000"
 
 # Define /tmp permissions
-tmp_dir_mode: '1777'
+os_tmp_dir_mode: '1777'
 
 # Define /tmp is a mountpoint.
 # If it is not, harden /tmp folder permissions
-tmp_mnt_enabled: false
+os_tmp_mnt_enabled: false
 
 # Define source mountpoint for folder /tmp
 # example: /dev/vg_system/lv_tmp
-tmp_mnt_src: ""
+os_tmp_mnt_src: ""
 
 # Define filesystem for tmp mount
 # default: ext4
-tmp_mnt_filesystem: "ext4"
+os_tmp_mnt_filesystem: "ext4"
 
 # Mount options for /tmp in /etc/fstab.
-tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'
+os_tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'
 

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -390,3 +390,19 @@ os_selinux_enabled: true
 # The values must be inside the 1000-999999999 range.
 os_sha_crypt_min_rounds: "640000"
 os_sha_crypt_max_rounds: "640000"
+
+# Define /tmp is a mountpoint.
+# If it is not, harden /tmp folder permissions
+tmp_mount_enabled: false
+
+# Define source mountpoint for folder /tmp
+# example: /dev/vg_system/lv_tmp
+tmp_mount_source: ""
+
+# Define filesystem for tmp mount
+# default: ext4
+tmp_mount_filesystem: "ext4"
+
+# Mount options for /tmp in /etc/fstab.
+tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'
+

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -397,7 +397,7 @@ tmp_mnt_enabled: false
 
 # Define source mountpoint for folder /tmp
 # example: /dev/vg_system/lv_tmp
-tmp_mnt_source: ""
+tmp_mnt_src: ""
 
 # Define filesystem for tmp mount
 # default: ext4

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -391,6 +391,9 @@ os_selinux_enabled: true
 os_sha_crypt_min_rounds: "640000"
 os_sha_crypt_max_rounds: "640000"
 
+# Define /tmp permissions
+tmp_dir_mode: '1777'
+
 # Define /tmp is a mountpoint.
 # If it is not, harden /tmp folder permissions
 tmp_mnt_enabled: false

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -85,7 +85,7 @@
   mount:
     path: /tmp
     src: '{{ tmp_mnt_src }}'
-    fstype: proc
+    fstype: '{{ tmp_mnt_filesystem }}'
     opts: '{{ tmp_mnt_options }}'
     state: mounted
   when: tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -96,7 +96,7 @@
     src: '{{ os_tmp_mnt_src }}'
     fstype: '{{ os_tmp_mnt_filesystem }}'
     opts: '{{ os_tmp_mnt_options }}'
-    state: remount
+    state: remounted
   when: os_tmp_mnt_enabled | bool
 
 - name: Harden permissions for /tmp directory

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -90,7 +90,7 @@
     state: present
   when: os_tmp_mnt_enabled | bool
 
-- name: Harden mount options for tmp
+- name: Mount tmp with hardened options
   mount:
     path: /tmp
     src: '{{ os_tmp_mnt_src }}'

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -88,7 +88,7 @@
     fstype: proc
     opts: '{{ tmp_mnt_options }}'
     state: mounted
-  when: tmp_mount_enabled | bool
+  when: tmp_mnt_enabled | bool
 
 - name: Optimize permissions for /tmp directory
   file:
@@ -96,4 +96,4 @@
     owner: 'root'
     group: 'root'
     mode: '1777'
-  when: not tmp_mount_enabled | bool
+  when: not tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -96,4 +96,3 @@
     owner: 'root'
     group: 'root'
     mode: '{{ tmp_dir_mode }}'
-  when: not tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -87,7 +87,16 @@
     src: '{{ tmp_mnt_src }}'
     fstype: '{{ tmp_mnt_filesystem }}'
     opts: '{{ tmp_mnt_options }}'
-    state: mounted
+    state: present
+  when: tmp_mnt_enabled | bool
+
+- name: Harden mount options for tmp
+  mount:
+    path: /tmp
+    src: '{{ tmp_mnt_src }}'
+    fstype: '{{ tmp_mnt_filesystem }}'
+    opts: '{{ tmp_mnt_options }}'
+    state: remount
   when: tmp_mnt_enabled | bool
 
 - name: Harden permissions for /tmp directory

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -88,7 +88,7 @@
     fstype: proc
     opts: '{{ tmp_mnt_options }}'
     state: mounted
-  when: tmp_mnt_enabled | bool
+  when: tmp_mount_enabled | bool
 
 - name: Optimize permissions for /tmp directory
   file:
@@ -96,4 +96,4 @@
     owner: 'root'
     group: 'root'
     mode: '1777'
-  when: not tmp_mnt_enabled | bool
+  when: not tmp_mount_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -81,7 +81,7 @@
     opts: '{{ proc_mnt_options }}'
     state: mounted
 
-- name: Optimize mount options for tmp
+- name: Harden mount options for tmp
   mount:
     path: /tmp
     src: '{{ tmp_mnt_src }}'

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -95,5 +95,5 @@
     dest: /tmp
     owner: 'root'
     group: 'root'
-    mode: '1777'
+    mode: '{{ tmp_dir_mode }}'
   when: not tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -81,15 +81,6 @@
     opts: '{{ proc_mnt_options }}'
     state: mounted
 
-- name: Harden mount options for tmp
-  mount:
-    path: /tmp
-    src: '{{ os_tmp_mnt_src }}'
-    fstype: '{{ os_tmp_mnt_filesystem }}'
-    opts: '{{ os_tmp_mnt_options }}'
-    state: present
-  when: os_tmp_mnt_enabled | bool
-
 - name: Mount tmp with hardened options
   mount:
     path: /tmp

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -84,24 +84,24 @@
 - name: Harden mount options for tmp
   mount:
     path: /tmp
-    src: '{{ tmp_mnt_src }}'
-    fstype: '{{ tmp_mnt_filesystem }}'
-    opts: '{{ tmp_mnt_options }}'
+    src: '{{ os_tmp_mnt_src }}'
+    fstype: '{{ os_tmp_mnt_filesystem }}'
+    opts: '{{ os_tmp_mnt_options }}'
     state: present
-  when: tmp_mnt_enabled | bool
+  when: os_tmp_mnt_enabled | bool
 
 - name: Harden mount options for tmp
   mount:
     path: /tmp
-    src: '{{ tmp_mnt_src }}'
-    fstype: '{{ tmp_mnt_filesystem }}'
-    opts: '{{ tmp_mnt_options }}'
+    src: '{{ os_tmp_mnt_src }}'
+    fstype: '{{ os_tmp_mnt_filesystem }}'
+    opts: '{{ os_tmp_mnt_options }}'
     state: remount
-  when: tmp_mnt_enabled | bool
+  when: os_tmp_mnt_enabled | bool
 
 - name: Harden permissions for /tmp directory
   file:
     dest: /tmp
     owner: 'root'
     group: 'root'
-    mode: '{{ tmp_dir_mode }}'
+    mode: '{{ os_tmp_dir_mode }}'

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -105,3 +105,12 @@
     owner: 'root'
     group: 'root'
     mode: '{{ os_tmp_dir_mode }}'
+
+- name: Harden mount options for tmp
+  mount:
+    path: /tmp
+    src: '{{ os_tmp_mnt_src }}'
+    fstype: '{{ os_tmp_mnt_filesystem }}'
+    opts: '{{ os_tmp_mnt_options }}'
+    state: present
+  when: os_tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -80,3 +80,20 @@
     fstype: proc
     opts: '{{ proc_mnt_options }}'
     state: mounted
+
+- name: Optimize mount options for tmp
+  mount:
+    path: /tmp
+    src: '{{ tmp_mnt_src }}'
+    fstype: proc
+    opts: '{{ tmp_mnt_options }}'
+    state: mounted
+  when: tmp_mnt_enabled | bool
+
+- name: Optimize permissions for /tmp directory
+  file:
+    dest: /tmp
+    owner: 'root'
+    group: 'root'
+    mode: '1777'
+  when: not tmp_mnt_enabled | bool

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -90,7 +90,7 @@
     state: mounted
   when: tmp_mnt_enabled | bool
 
-- name: Optimize permissions for /tmp directory
+- name: Harden permissions for /tmp directory
   file:
     dest: /tmp
     owner: 'root'

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -117,7 +117,7 @@ tmp_mnt_enabled: false
 
 # Define source mountpoint for folder /tmp
 # example: /dev/vg_system/lv_tmp
-tmp_mnt_source: ""
+tmp_mnt_src: ""
 
 # Define filesystem for tmp mount
 # default: ext4

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -111,6 +111,9 @@ os_security_suid_sgid_system_whitelist:
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
 
+# Define /tmp permissions
+tmp_dir_mode: '1777'
+
 # Define /tmp is a mountpoint.
 # If it is not, harden /tmp folder permissions
 tmp_mnt_enabled: false

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -110,3 +110,18 @@ os_security_suid_sgid_system_whitelist:
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
+
+# Define /tmp is a mountpoint.
+# If it is not, harden /tmp folder permissions
+tmp_mnt_enabled: false
+
+# Define source mountpoint for folder /tmp
+# example: /dev/vg_system/lv_tmp
+tmp_mnt_source: ""
+
+# Define filesystem for tmp mount
+# default: ext4
+tmp_mnt_filesystem: "ext4"
+
+# Mount options for /tmp in /etc/fstab.
+tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -110,20 +110,3 @@ os_security_suid_sgid_system_whitelist:
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
-# Define /tmp permissions
-os_tmp_dir_mode: '1777'
-
-# Define /tmp is a mountpoint.
-# If it is not, harden /tmp folder permissions
-os_tmp_mnt_enabled: false
-
-# Define source mountpoint for folder /tmp
-# example: /dev/vg_system/lv_tmp
-os_tmp_mnt_src: ""
-
-# Define filesystem for tmp mount
-# default: ext4
-os_tmp_mnt_filesystem: "ext4"
-
-# Mount options for /tmp in /etc/fstab.
-os_tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -111,19 +111,19 @@ os_security_suid_sgid_system_whitelist:
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
 # Define /tmp permissions
-tmp_dir_mode: '1777'
+os_tmp_dir_mode: '1777'
 
 # Define /tmp is a mountpoint.
 # If it is not, harden /tmp folder permissions
-tmp_mnt_enabled: false
+os_tmp_mnt_enabled: false
 
 # Define source mountpoint for folder /tmp
 # example: /dev/vg_system/lv_tmp
-tmp_mnt_src: ""
+os_tmp_mnt_src: ""
 
 # Define filesystem for tmp mount
 # default: ext4
-tmp_mnt_filesystem: "ext4"
+os_tmp_mnt_filesystem: "ext4"
 
 # Mount options for /tmp in /etc/fstab.
-tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'
+os_tmp_mnt_options: 'rw,nosuid,nodev,noexec,relatime'

--- a/roles/os_hardening/vars/main.yml
+++ b/roles/os_hardening/vars/main.yml
@@ -110,7 +110,6 @@ os_security_suid_sgid_system_whitelist:
 
 # system accounts that do not get their login disabled and pasword changed
 os_always_ignore_users: ['root', 'sync', 'shutdown', 'halt']
-
 # Define /tmp permissions
 tmp_dir_mode: '1777'
 


### PR DESCRIPTION
Add option to manage handling with /tmp directory. Its possible to mount a device to /tmp with hardened options. If there is no need to mount a disk, this function ensures permissions on /tmp directory.

If you need changes, tell me, please.