### PR TITLE
delete obsolete release drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           path: ./CHANGELOGRELEASE.md
 
+      - name: Delete old drafts
+        uses: hugo19941994/delete-draft-releases@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release draft
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
By using release drafter action we are creating release drafts with every merge to master. All prior drafts become obsolete with a new merge. This action will delete all old drafts before creating a new one and keep our release view clean.