### PR TITLE
add VM tests for os_hardening 

### DIFF
--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -29,7 +29,7 @@ jobs:
           - debian9
           - debian10
           # - opensuse42  # opensuse currently cannot get an ip address
-          - arch
+          # - arch  - arch is currently not supported by cinc-auditor
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create default collection path symlink
         run: |
           mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
+          ln -fs /opt/actions-runner/_work/ansible-collection-hardening/ansible-collection-hardening/ansible_collections /home/runner/.ansible/collections
 
       - name: Test with molecule
         run: |

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -28,6 +28,8 @@ jobs:
           - ubuntu2004
           - debian9
           - debian10
+          - opensuse42
+          - arch
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         molecule_distro:
           - centos7
-          - rocky8
-          - ubuntu1804
-          - ubuntu2004
-          - debian9
-          - debian10
+          ##- rocky8
+          ##- ubuntu1804
+          ##- ubuntu2004
+          ##- debian9
+          ##- debian10
           # - opensuse42  # opensuse currently cannot get an ip address
           # - arch  - arch is currently not supported by cinc-auditor
     steps:

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -28,7 +28,7 @@ jobs:
           - ubuntu2004
           - debian9
           - debian10
-          - opensuse42
+          # - opensuse42  # opensuse currently cannot get an ip address
           - arch
     steps:
       - name: Checkout repo

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -22,18 +22,18 @@ jobs:
       fail-fast: false
       matrix:
         molecule_distro:
+          # - centos7
+          # - rocky8
           - ubuntu1804
+          # - ubuntu2004
+          # - debian9
+          # - debian10
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
 
       - name: Create default collection path symlink
         run: |

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         molecule_distro:
           - centos7
-          ##- rocky8
-          ##- ubuntu1804
-          ##- ubuntu2004
-          ##- debian9
-          ##- debian10
+          - rocky8
+          - ubuntu1804
+          - ubuntu2004
+          - debian9
+          - debian10
           # - opensuse42  # opensuse currently cannot get an ip address
           # - arch  - arch is currently not supported by cinc-auditor
     steps:

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -22,12 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         molecule_distro:
-          # - centos7
-          # - rocky8
+          - centos7
+          - rocky8
           - ubuntu1804
-          # - ubuntu2004
-          # - debian9
-          # - debian10
+          - ubuntu2004
+          - debian9
+          - debian10
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -1,0 +1,44 @@
+---
+name: "devsec.os_hardening"
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    paths:
+      - 'roles/os_hardening/**'
+      - 'molecule/os_hardening_vm/**'
+      - '.github/workflows/os_hardening_vm.yml'
+  pull_request:
+    paths:
+      - 'roles/os_hardening/**'
+      - 'molecule/os_hardening_vm/**'
+      - '.github/workflows/os_hardening_vm.yml'
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        molecule_distro:
+          - ubuntu1804
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/devsec/hardening
+          submodules: true
+
+      - name: Create default collection path symlink
+        run: |
+          mkdir -p /home/runner/.ansible
+          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
+
+      - name: Test with molecule
+        run: |
+          molecule --version
+          molecule test -s os_hardening
+        env:
+          MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
+        working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -1,5 +1,5 @@
 ---
-name: "devsec.os_hardening"
+name: "devsec.os_hardening VM"
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   push:
@@ -38,7 +38,7 @@ jobs:
       - name: Test with molecule
         run: |
           molecule --version
-          molecule test -s os_hardening
+          molecule test -s os_hardening_vm
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
         working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -30,6 +30,11 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
       - name: Create default collection path symlink
         run: |
           mkdir -p /home/runner/.ansible

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ansible Collection - devsec.hardening
 
 ![devsec.os_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.os_hardening/badge.svg)
+![devsec.os_hardening VM](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.os_hardening%20VM/badge.svg)
 ![devsec.ssh_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.ssh_hardening/badge.svg)
 ![devsec.nginx_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.nginx_hardening/badge.svg)
 ![devsec.mysql_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.mysql_hardening/badge.svg)

--- a/molecule/os_hardening/converge.yml
+++ b/molecule/os_hardening/converge.yml
@@ -26,7 +26,6 @@
     os_security_suid_sgid_blacklist: ['/bin/umount']
     os_security_suid_sgid_whitelist: ['/usr/bin/rlogin']
     os_filesystem_whitelist: []
-    os_ctrlaltdel_disabled: true
     os_yum_repo_file_whitelist: ['foo.repo']
     sysctl_config:
       net.ipv4.ip_forward: 0

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -55,7 +55,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests  # noqa ignore-errors
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit  --waiver-file waivers.yaml https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/os_hardening_vm/INSTALL.rst
+++ b/molecule/os_hardening_vm/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -19,5 +19,6 @@
     os_auth_pam_passwdqc_enable: false
     os_auth_lockout_time: 15
     os_yum_repo_file_whitelist: ['foo.repo']
+    os_ctrlaltdel_disabled: true
     os_mnt_boot_enabled: true
     os_mnt_boot_src: "/dev/vda1"

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -15,6 +15,7 @@
     os_auth_pam_passwdqc_enable: false
     os_auth_lockout_time: 15
     os_yum_repo_file_whitelist: ['foo.repo']
+    os_mnt_boot_enabled: true
 
 # - name: wrapper playbook for kitchen testing "ansible-os-hardening"
 #  hosts: all

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -1,0 +1,38 @@
+---
+- name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
+  hosts: all
+  become: true
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  collections:
+    - devsec.hardening
+  tasks:
+    - include_role:
+        name: os_hardening
+  vars:
+    os_auth_pam_passwdqc_enable: false
+    os_auth_lockout_time: 15
+    os_yum_repo_file_whitelist: ['foo.repo']
+
+# - name: wrapper playbook for kitchen testing "ansible-os-hardening"
+#  hosts: all
+#  become: true
+#  collections:
+#    - devsec.hardening
+#  vars:
+#    os_auditd_enabled: false
+#  tasks:
+#    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
+#      set_fact:
+#        ansible_python_interpreter: "/usr/bin/python3"
+#      when: ansible_facts.distribution == 'Fedora'
+#
+#    - name: Run the equivalent of "apt-get update" as a separate step
+#      apt:
+#        update_cache: yes
+#      when: ansible_facts.os_family == 'Debian'
+#
+#    - include_role:
+#        name: os_hardening

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -16,6 +16,7 @@
     os_auth_lockout_time: 15
     os_yum_repo_file_whitelist: ['foo.repo']
     os_mnt_boot_enabled: true
+    os_mnt_boot_src: "/dev/vda1"
 
 # - name: wrapper playbook for kitchen testing "ansible-os-hardening"
 #  hosts: all

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -9,6 +9,10 @@
   collections:
     - devsec.hardening
   tasks:
+    - name: override for arch
+      set_fact: 
+        os_mnt_boot_enabled: false
+      when: ansible_facts.os_family == 'Archlinux'
     - include_role:
         name: os_hardening
   vars:
@@ -17,24 +21,3 @@
     os_yum_repo_file_whitelist: ['foo.repo']
     os_mnt_boot_enabled: true
     os_mnt_boot_src: "/dev/vda1"
-
-# - name: wrapper playbook for kitchen testing "ansible-os-hardening"
-#  hosts: all
-#  become: true
-#  collections:
-#    - devsec.hardening
-#  vars:
-#    os_auditd_enabled: false
-#  tasks:
-#    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
-#      set_fact:
-#        ansible_python_interpreter: "/usr/bin/python3"
-#      when: ansible_facts.distribution == 'Fedora'
-#
-#    - name: Run the equivalent of "apt-get update" as a separate step
-#      apt:
-#        update_cache: yes
-#      when: ansible_facts.os_family == 'Debian'
-#
-#    - include_role:
-#        name: os_hardening

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -19,6 +19,5 @@
     os_auth_pam_passwdqc_enable: false
     os_auth_lockout_time: 15
     os_yum_repo_file_whitelist: ['foo.repo']
-    os_ctrlaltdel_disabled: true
     os_mnt_boot_enabled: true
     os_mnt_boot_src: "/dev/vda1"

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -14,12 +14,16 @@ platforms:
     cpus: 2
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_PIPELINING: "True"
   config_options:
     defaults:
       interpreter_python: auto_silent
       callback_whitelist: profile_tasks, timer, yaml
 verifier:
   name: ansible
+  env:
+    ANSIBLE_PIPELINING: "True"
 
 scenario:
   create_sequence:

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -9,7 +9,7 @@ driver:
     name: libvirt
 platforms:
   - name: instance
-    image: "generic/${MOLECULE_DISTRO}"
+    box: "generic/${MOLECULE_DISTRO}"
 provisioner:
   name: ansible
   config_options:

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -10,6 +10,8 @@ driver:
 platforms:
   - name: instance
     box: "generic/${MOLECULE_DISTRO}"
+    memory: 1024
+    cpus: 2
 provisioner:
   name: ansible
   config_options:

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -1,0 +1,51 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/os_hardening/requirements.yml
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+platforms:
+  - name: instance
+    image: "generic/${MOLECULE_DISTRO}"
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callback_whitelist: profile_tasks, timer, yaml
+verifier:
+  name: ansible
+
+scenario:
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - dependency
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -1,0 +1,60 @@
+---
+- name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
+  hosts: all
+  become: true
+  collections:
+    - devsec.hardening
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  tasks:
+    - name: set ansible_python_interpreter to "/usr/bin/python3" on fedora
+      set_fact:
+        ansible_python_interpreter: "/usr/bin/python3"
+      when: ansible_facts.distribution == 'Fedora'
+
+    - name: Run the equivalent of "apt-get update && apt-get upgrade"
+      apt:
+        name: "*"
+        state: latest
+        update_cache: true
+      when: ansible_os_family == 'Debian'
+
+    - name: install required tools on SuSE
+      # cannot use zypper module, since it depends on python-xml
+      shell: "zypper -n install python-xml"
+      when: ansible_facts.os_family == 'Suse'
+
+    - name: install required tools on fedora
+      dnf:
+        name:
+          - python
+          - findutils
+          - procps-ng
+      when: ansible_facts.distribution == 'Fedora'
+
+    - name: install required tools on Arch
+      community.general.pacman:
+        name:
+          - awk
+        state: present
+        update_cache: true
+      when: ansible_facts.os_family == 'Archlinux'
+
+    - name: install required tools on RHEL  # noqa ignore-errors
+      yum:
+        name:
+          - openssh-clients
+          - openssh
+        state: present
+        update_cache: true
+      ignore_errors: true
+
+    - name: create recursing symlink to test minimize access
+      shell: "rm -f /usr/bin/zzz && ln -s /usr/bin /usr/bin/zzz"
+      changed_when: false
+
+    - name: include YUM prepare tasks
+      include_tasks: prepare_tasks/yum.yml
+      when: ansible_facts.os_family == 'RedHat'

--- a/molecule/os_hardening_vm/prepare_tasks/yum.yml
+++ b/molecule/os_hardening_vm/prepare_tasks/yum.yml
@@ -1,0 +1,16 @@
+---
+- name: create 'foo' repository
+  ansible.builtin.yum_repository:
+    name: foo
+    description: mandatory description
+    baseurl: file:///mandatory-url
+    enabled: false
+    gpgcheck: false
+
+- name: create 'bar' repository
+  ansible.builtin.yum_repository:
+    name: bar
+    description: mandatory description
+    baseurl: file:///mandatory-url
+    enabled: false
+    gpgcheck: false

--- a/molecule/os_hardening_vm/requirements.yml
+++ b/molecule/os_hardening_vm/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles:
+  - geerlingguy.git

--- a/molecule/os_hardening_vm/verify.yml
+++ b/molecule/os_hardening_vm/verify.yml
@@ -55,7 +55,7 @@
       shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
 
     - name: Execute cinc-auditor tests  # noqa ignore-errors
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit  --waiver-file waivers.yaml https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/os_hardening_vm/verify.yml
+++ b/molecule/os_hardening_vm/verify.yml
@@ -68,16 +68,3 @@
       fail:
         msg: "Inspec failed to validate"
       when: test_results.rc != 0
-
-    # test if variable can be overridden
-    - name: workaround for https://github.com/ansible/ansible/issues/66304
-      set_fact:
-        os_env_umask: "027 #override"
-
-    - include_role:
-        name: os_hardening
-
-    - name: verify os_env_umask
-      shell:
-        cmd: "grep '027 #override' /etc/login.defs"
-      changed_when: false

--- a/molecule/os_hardening_vm/verify.yml
+++ b/molecule/os_hardening_vm/verify.yml
@@ -1,0 +1,83 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  roles:
+    - geerlingguy.git
+  tasks:
+    - name: install fake SuSE-release for cinc compatibility
+      copy:
+        content: |
+          openSUSE Faked Enterprise 2020 (x86_64)
+          VERSION = 2020
+          CODENAME = Faked Feature
+        dest: /etc/SuSE-release
+        owner: root
+        group: root
+        mode: '0444'
+      when: ansible_facts.os_family == 'Suse'
+
+    - name: install git for SuSE since geerlinguy.git does not support it
+      zypper:
+        name: git
+        state: present
+      when: ansible_facts.os_family == 'Suse'
+
+    - name: Run the equivalent of "apt-get update" as a separate step
+      apt:
+        update_cache: true
+      when: ansible_facts.os_family == 'Debian'
+
+    - name: install required tools on debian
+      apt:
+        name: procps
+      when: ansible_facts.os_family == 'Debian'
+
+    - name: include PAM tests
+      include_tasks: verify_tasks/pam.yml
+      when: ansible_facts.distribution in ['Debian', 'Ubuntu'] or ansible_facts.os_family == 'RedHat'
+
+    - name: include YUM tests
+      include_tasks: verify_tasks/yum.yml
+      when: ansible_facts.os_family == 'RedHat'
+
+    - name: download cinc-auditor
+      get_url:
+        url: https://omnitruck.cinc.sh/install.sh
+        dest: /tmp/install.sh
+        mode: '0775'
+
+    - name: install cinc-auditor
+      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
+
+    - name: Execute cinc-auditor tests  # noqa ignore-errors
+      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit  --waiver-file waivers.yaml https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
+      register: test_results
+      changed_when: false
+      ignore_errors: true
+
+    - name: Display details about the cinc-auditor results
+      debug:
+        msg: "{{ test_results.stdout_lines }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Inspec failed to validate"
+      when: test_results.rc != 0
+
+    # test if variable can be overridden
+    - name: workaround for https://github.com/ansible/ansible/issues/66304
+      set_fact:
+        os_env_umask: "027 #override"
+
+    - include_role:
+        name: os_hardening
+
+    - name: verify os_env_umask
+      shell:
+        cmd: "grep '027 #override' /etc/login.defs"
+      changed_when: false

--- a/molecule/os_hardening_vm/verify_tasks/pam.yml
+++ b/molecule/os_hardening_vm/verify_tasks/pam.yml
@@ -1,0 +1,59 @@
+---
+- name: download pam-tester
+  get_url:
+    url: https://github.com/schurzi/pam-tester/releases/download/latest/pam-tester
+    dest: /bin/pam-tester
+    mode: 0555
+
+- name: set password for test
+  set_fact:
+    test_pw: "myTest!pw"
+
+- name: set locale for test
+  set_fact:
+    locale: "en_US.UTF-8"
+  when:
+    - ansible_facts.os_family == 'RedHat'
+    - ansible_facts.distribution_major_version < '8'
+
+- name: create testuser
+  user:
+    name: testuser
+    password: "{{ test_pw | password_hash('sha512') }}"
+
+- name: check successfull login with correct password
+  shell:
+    cmd: "pam-tester --user testuser --password {{ test_pw }}"
+  environment:
+    TMPDIR: /var/tmp
+    LC_ALL: "{{ locale | default('C.UTF-8') }}"
+    LANG: "{{ locale | default('C.UTF-8') }}"
+
+- name: check unsuccessfull login with incorrect password
+  shell:
+    cmd: "pam-tester --user testuser --password {{ test_pw }}fail --expectfail"
+  environment:
+    TMPDIR: /var/tmp
+    LC_ALL: "{{ locale | default('C.UTF-8') }}"
+    LANG: "{{ locale | default('C.UTF-8') }}"
+  with_sequence: count=6
+
+- name: check unsuccessfull login, with correct password (lockout)
+  shell:
+    cmd: "pam-tester --user testuser --password {{ test_pw }} --expectfail"
+  environment:
+    TMPDIR: /var/tmp
+    LC_ALL: "{{ locale | default('C.UTF-8') }}"
+    LANG: "{{ locale | default('C.UTF-8') }}"
+
+- name: wait for account to unlock
+  pause:
+    seconds: 20
+
+- name: check successfull login
+  shell:
+    cmd: "pam-tester --user testuser --password {{ test_pw }}"
+  environment:
+    TMPDIR: /var/tmp
+    LC_ALL: "{{ locale | default('C.UTF-8') }}"
+    LANG: "{{ locale | default('C.UTF-8') }}"

--- a/molecule/os_hardening_vm/verify_tasks/yum.yml
+++ b/molecule/os_hardening_vm/verify_tasks/yum.yml
@@ -1,0 +1,8 @@
+---
+- name: verify 'gpgcheck' was not enabled for 'foo' repository (in whitelist)
+  command: grep -e 'gpgcheck\s*=\s*0' /etc/yum.repos.d/foo.repo
+  changed_when: false
+
+- name: verify 'gpgcheck' was enabled for 'bar' repository (not in whitelist)
+  command: grep -e 'gpgcheck\s*=\s*1' /etc/yum.repos.d/bar.repo
+  changed_when: false

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -1,6 +1,7 @@
 # devsec.os_hardening
 
 ![devsec.os_hardening](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.os_hardening/badge.svg)
+![devsec.os_hardening VM](https://github.com/dev-sec/ansible-os-hardening/workflows/devsec.os_hardening%20VM/badge.svg)
 
 ## Looking for the old ansible-os-hardening role?
 

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -96,7 +96,7 @@
   register: bootmount
   when:
     - os_mnt_boot_enabled | bool
-    - boot_exists | bool
+    - boot_exists.stat.exists | bool
 
 - name: Harden permissions for /boot directory
   file:
@@ -104,7 +104,7 @@
     owner: 'root'
     group: 'root'
     mode: '{{ os_mnt_boot_dir_mode }}'
-  when:  boot_exists | bool
+  when:  boot_exists.stat.exists | bool
 
 - name: Mount /dev with hardened options
   mount:

--- a/roles/os_hardening/tasks/sysctl.yml
+++ b/roles/os_hardening/tasks/sysctl.yml
@@ -48,6 +48,11 @@
         sysctl_config: '{{ sysctl_config | combine(sysctl_custom_config) }}'
       when: sysctl_custom_config | default()
 
+    - name: Remove entries sysctl-dict if os does not support these
+      set_fact:
+        sysctl_config: '{{ sysctl_config | combine(sysctl_unsupported_entries) }}'
+      when: sysctl_unsupported_entries | default()
+
     # sysctl_rhel_config is kept for backwards-compatibility. use sysctl_custom_config instead
     - name: Create a combined sysctl-dict if os-dependent sysctls are defined
       set_fact:

--- a/roles/os_hardening/tasks/sysctl.yml
+++ b/roles/os_hardening/tasks/sysctl.yml
@@ -50,7 +50,7 @@
 
     - name: Remove entries sysctl-dict if os does not support these
       set_fact:
-        sysctl_config: '{{ sysctl_config | combine(sysctl_unsupported_entries) }}'
+        sysctl_config: '{{ sysctl_config | difference(sysctl_unsupported_entries) }}'
       when: sysctl_unsupported_entries | default()
 
     # sysctl_rhel_config is kept for backwards-compatibility. use sysctl_custom_config instead

--- a/roles/os_hardening/tasks/sysctl.yml
+++ b/roles/os_hardening/tasks/sysctl.yml
@@ -48,11 +48,6 @@
         sysctl_config: '{{ sysctl_config | combine(sysctl_custom_config) }}'
       when: sysctl_custom_config | default()
 
-    - name: Remove entries sysctl-dict if os does not support these
-      set_fact:
-        sysctl_config: '{{ sysctl_config | difference(sysctl_unsupported_entries) }}'
-      when: sysctl_unsupported_entries | default()
-
     # sysctl_rhel_config is kept for backwards-compatibility. use sysctl_custom_config instead
     - name: Create a combined sysctl-dict if os-dependent sysctls are defined
       set_fact:
@@ -73,6 +68,7 @@
         reload: true
         ignoreerrors: true
       with_dict: '{{ sysctl_config }}'
+      when: item.key not in sysctl_unsupported_entries
   when: ansible_virtualization_type not in ['docker', 'lxc', 'openvz']
 
 - name: Apply ufw defaults

--- a/roles/os_hardening/tasks/sysctl.yml
+++ b/roles/os_hardening/tasks/sysctl.yml
@@ -68,7 +68,7 @@
         reload: true
         ignoreerrors: true
       with_dict: '{{ sysctl_config }}'
-      when: item.key not in sysctl_unsupported_entries
+      when: item.key not in sysctl_unsupported_entries | default()
   when: ansible_virtualization_type not in ['docker', 'lxc', 'openvz']
 
 - name: Apply ufw defaults

--- a/roles/os_hardening/tasks/yum.yml
+++ b/roles/os_hardening/tasks/yum.yml
@@ -37,7 +37,7 @@
     replace: 'gpgcheck=1'
     mode: '0644'
   register: status
-  failed_when: status.rc is defined and status.rc != 257
+  failed_when: status.rc is defined and status.rc not in (257, 0)
   loop:
     - '/etc/yum.conf'
     - '/etc/dnf/dnf.conf'

--- a/roles/os_hardening/vars/RedHat_7.yml
+++ b/roles/os_hardening/vars/RedHat_7.yml
@@ -43,3 +43,7 @@ modprobe_package: 'module-init-tools'
 auditd_package: 'audit'
 
 hidepid_option: '0'  # allowed values: 0, 1, 2
+
+sysctl_unsupported_entries:
+  - 'fs.protected_fifos'
+  - 'fs.protected_regular'

--- a/roles/os_hardening/vars/RedHat_7.yml
+++ b/roles/os_hardening/vars/RedHat_7.yml
@@ -45,5 +45,5 @@ auditd_package: 'audit'
 hidepid_option: '0'  # allowed values: 0, 1, 2
 
 sysctl_unsupported_entries:
-  - 'fs.protected_fifos'
-  - 'fs.protected_regular'
+  fs.protected_fifos:
+  fs.protected_regular:

--- a/roles/os_hardening/vars/RedHat_7.yml
+++ b/roles/os_hardening/vars/RedHat_7.yml
@@ -45,5 +45,5 @@ auditd_package: 'audit'
 hidepid_option: '0'  # allowed values: 0, 1, 2
 
 sysctl_unsupported_entries:
-  fs.protected_fifos:
-  fs.protected_regular:
+  - 'fs.protected_fifos'
+  - 'fs.protected_regular'


### PR DESCRIPTION
Wen need to use full VMs to test every aspect of our `os_hardening` role. These are now integrated and check all controls of the supporting baseline.

While implementing there were some minor bugs to fix:
- check for `/boot` existence was not correct
- some sysctls were unsupported on older platforms (an exclude mechanism was introduced)
- gpg-check for yum config did not account for already correct configuration
