### PR TITLE
Fix broken mode for /var/log/audit

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -428,7 +428,7 @@ os_mnt_var_log_src: ""
 os_mnt_var_log_options: 'rw,nosuid,nodev,noexec'
 os_mnt_var_log_filesystem: "ext4"
 
-os_mnt_var_log_audit_dir_mode: '0640'
+os_mnt_var_log_audit_dir_mode: '0700'
 os_mnt_var_log_audit_enabled: false
 os_mnt_var_log_audit_src: ""
 os_mnt_var_log_audit_options: 'rw,nosuid,nodev,noexec'


### PR DESCRIPTION
#531 introduced a broken permission on /var/log/audit which prevents auditd from starting with the following error:

```
Unable to open /var/log/audit/audit.log (Permission denied)
```

This PR fixes the issue by using the default permission set by auditd (`0700`).