### PR TITLE
rework filesystem hardening

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -300,8 +300,14 @@ We know that this is the case on Raspberry Pi.
   - Default: `rw,nosuid,nodev,noexec`
   - Description: Configure mount options for /boot
 - `os_mnt_boot_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /boot
+  - Default: `""`
+  - Description: Configure file system for fstab entry /boot. If empty, the current file system type will be used.
+- `os_mnt_boot_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_boot_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_dev_dir_mode`
   - Default: `0755`
   - Description: Set default perimissions for /dev
@@ -315,8 +321,14 @@ We know that this is the case on Raspberry Pi.
   - Default: `'rw,nosuid,noexec'`
   - Description: Configure mount options for /dev
 - `os_mnt_dev_filesystem`
-  - Default: `ext4`
+  - Default: `devtmpfs`
   - Description: Configure file system for fstab entry /dev
+- `os_mnt_dev_dump`
+  - Default: `0`
+  - Description: Configure dump for fstab entry /var/tmp.
+- `os_mnt_dev_passno`
+  - Default: `0`
+  - Description: Configure passno for fstab entry /var/tmp.
 - `os_mnt_dev_shm_dir_mode`
   - Default: `1777`
   - Description: Set default perimissions for /dev/shm
@@ -330,8 +342,14 @@ We know that this is the case on Raspberry Pi.
   - Default: `rw,nosuid,nodev,noexec`
   - Description: Configure mount options for /dev/shm
 - `os_mnt_dev_shm_filesystem`
-  - Default: `ext4`
+  - Default: `tmpfs`
   - Description: Configure file system for fstab entry /dev/shm
+- `os_mnt_dev_shm_dump`
+  - Default: `0`
+  - Description: Configure dump for fstab entry /var/tmp.
+- `os_mnt_dev_shm_passno`
+  - Default: `0`
+  - Description: Configure passno for fstab entry /var/tmp.
 - `os_mnt_home_dir_mode`
   - Default: `0755`
   - Description: Set default perimissions for /home
@@ -340,13 +358,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to configure /home mountpoint
 - `os_mnt_home_src`
   - Default: `""`
-  - Description: Set mount source for /home
+  - Description: Set mount source for /home. If empty, the current file system source device will be used.
 - `os_mnt_home_options`
   - Default: `rw,nosuid,nodev`
   - Description: Configure mount options for /home
 - `os_mnt_home_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /home
+  - Default: `""`
+  - Description: Configure file system for fstab entry /home. If empty, the current file system type will be used.
+- `os_mnt_home_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_home_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_run_dir_mode`
   - Default: `0755`
   - Description: Set default perimissions for /run
@@ -360,8 +384,35 @@ We know that this is the case on Raspberry Pi.
   - Default: `rw,nosuid,nodev`
   - Description: Configure mount options for /run
 - `os_mnt_run_filesystem`
-  - Default: `ext4`
+  - Default: `tmpfs`
   - Description: Configure file system for fstab entry /run
+- `os_mnt_run_dump`
+  - Default: `0`
+  - Description: Configure dump for fstab entry /var/tmp.
+- `os_mnt_run_passno`
+  - Default: `0`
+  - Description: Configure passno for fstab entry /var/tmp.
+- `os_mnt_tmp_dir_mode`
+  - Default: `1777`
+  - Description: Set default perimissions for /tmp
+- `os_mnt_tmp_enabled`
+  - Default: `false`
+  - Description: Set to true to configure /tmp mountpoint
+- `os_mnt_tmp_src`
+  - Default: `""`
+  - Description: Set mount source for /tmp. If empty, the current file system source device will be used.
+- `os_mnt_tmp_options`
+  - Default: `rw,nosuid,nodev,noexec`
+  - Description: Configure mount options for /tmp
+- `os_mnt_tmp_filesystem`
+  - Default: `""`
+  - Description: Configure file system for fstab entry /tmp. If empty, the current file system type will be used.
+- `os_mnt_tmp_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_tmp_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_var_dir_mode`
   - Default: `0755`
   - Description: Set default perimissions for /var
@@ -370,13 +421,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to configure /var mountpoint
 - `os_mnt_var_src`
   - Default: `""`
-  - Description: Set mount source for /var
+  - Description: Set mount source for /var. If empty, the current file system source device will be used.
 - `os_mnt_var_options`
   - Default: `rw,nosuid,nodev`
   - Description: Configure mount options for /var
 - `os_mnt_var_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /var
+  - Default: `""`
+  - Description: Configure file system for fstab entry /var. If empty, the current file system type will be used.
+- `os_mnt_var_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_var_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_var_log_dir_mode`
   - Default: `0755`
   - Description: Set default perimissions for /var/log
@@ -385,13 +442,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to configure /var/log mountpoint
 - `os_mnt_var_log_src`
   - Default: `""`
-  - Description: Set mount source for /var/log
+  - Description: Set mount source for /var/log. If empty, the current file system source device will be used.
 - `os_mnt_var_log_options`
   - Default: `rw,nosuid,nodev,noexec`
   - Description: Configure mount options for /var/log
 - `os_mnt_var_log_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /var/log
+  - Default: `""`
+  - Description: Configure file system for fstab entry /var/log. If empty, the current file system type will be used.
+- `os_mnt_var_log_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_var_log_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_var_log_audit_dir_mode`
   - Default: `0640`
   - Description: Set default perimissions for /var/log/audit
@@ -400,13 +463,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to configure /var/log/audit mountpoint
 - `os_mnt_var_log_audit_src`
   - Default: `""`
-  - Description: Set mount source for /var/log/audit
+  - Description: Set mount source for /var/log/audit. If empty, the current file system source device will be used.
 - `os_mnt_var_log_audit_options`
   - Default: `rw,nosuid,nodev,noexec`
   - Description: Configure mount options for /var/log/audit
 - `os_mnt_var_log_audit_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /var/log/audit
+  - Default: `""`
+  - Description: Configure file system for fstab entry /var/log/audit. If empty, the current file system type will be used.
+- `os_mnt_var_log_audit_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_var_log_audit_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_mnt_var_tmp_dir_mode`
   - Default: `1777`
   - Description: Set default perimissions for /var/tmp
@@ -415,13 +484,19 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to true to configure /var/tmp mountpoint
 - `os_mnt_var_tmp_src`
   - Default: `""`
-  - Description: Set mount source for /var/tmp
+  - Description: Set mount source for /var/tmp. If empty, the current file system source device will be used.
 - `os_mnt_var_tmp_options`
   - Default: `rw,nosuid,nodev,noexec`
   - Description: Configure mount options for /var/tmp
 - `os_mnt_var_tmp_filesystem`
-  - Default: `ext4`
-  - Description: Configure file system for fstab entry /var/tmp
+  - Default: `""`
+  - Description: Configure file system for fstab entry /var/tmp. If empty, the current file system type will be used.
+- `os_mnt_var_tmp_dump`
+  - Default: ext3 + ext4 `1` / other `0`
+  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
+- `os_mnt_var_tmp_passno`
+  - Default: ext3 + ext4 `2` / other `0`
+  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
 - `os_netrc_enabled`
   - Default: `True`
   - Description: Configure filesystem for existence of .netrc file in homedir

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -390,55 +390,81 @@ os_mnt_boot_dir_mode: '0700'
 os_mnt_boot_enabled: false
 os_mnt_boot_src: ""
 os_mnt_boot_options: 'rw,nosuid,nodev,noexec'
-os_mnt_boot_filesystem: 'ext4'
+os_mnt_boot_filesystem: ""
+os_mnt_boot_dump: ""
+os_mnt_boot_passno: ""
 
 os_mnt_dev_dir_mode: '0755'
 os_mnt_dev_enabled: true
 os_mnt_dev_src: "devtmpfs"
 os_mnt_dev_options: 'rw,nosuid,noexec'
 os_mnt_dev_filesystem: "devtmpfs"
+os_mnt_dev_dump: ""
+os_mnt_dev_passno: ""
 
 os_mnt_dev_shm_dir_mode: '1777'
 os_mnt_dev_shm_enabled: true
 os_mnt_dev_shm_src: "tmpfs"
 os_mnt_dev_shm_options: 'rw,nosuid,nodev,noexec'
 os_mnt_dev_shm_filesystem: "tmpfs"
+os_mnt_dev_shm_dump: ""
+os_mnt_dev_shm_passno: ""
 
 os_mnt_home_dir_mode: '0755'
 os_mnt_home_enabled: false
 os_mnt_home_src: ""
 os_mnt_home_options: 'rw,nosuid,nodev'
-os_mnt_home_filesystem: "ext4"
+os_mnt_home_filesystem: ""
+os_mnt_home_dump: ""
+os_mnt_home_passno: ""
 
 os_mnt_run_dir_mode: '0755'
 os_mnt_run_enabled: true
 os_mnt_run_src: "tmpfs"
 os_mnt_run_options: 'rw,nosuid,nodev'
 os_mnt_run_filesystem: "tmpfs"
+os_mnt_run_dump: ""
+os_mnt_run_passno: ""
+
+os_mnt_tmp_dir_mode: '1777'
+os_mnt_tmp_enabled: false
+os_mnt_tmp_src: ""
+os_mnt_tmp_options: 'rw,nosuid,nodev,noexec'
+os_mnt_tmp_filesystem: ""
+os_mnt_tmp_dump: ""
+os_mnt_tmp_passno: ""
 
 os_mnt_var_dir_mode: '0755'
 os_mnt_var_enabled: false
 os_mnt_var_src: ""
 os_mnt_var_options: 'rw,nosuid,nodev'
-os_mnt_var_filesystem: "ext4"
+os_mnt_var_filesystem: ""
+os_mnt_var_dump: ""
+os_mnt_var_passno: ""
 
 os_mnt_var_log_dir_mode: '0755'
 os_mnt_var_log_enabled: false
 os_mnt_var_log_src: ""
 os_mnt_var_log_options: 'rw,nosuid,nodev,noexec'
-os_mnt_var_log_filesystem: "ext4"
+os_mnt_var_log_filesystem: ""
+os_mnt_var_log_dump: ""
+os_mnt_var_log_passno: ""
 
 os_mnt_var_log_audit_dir_mode: '0700'
 os_mnt_var_log_audit_enabled: false
 os_mnt_var_log_audit_src: ""
 os_mnt_var_log_audit_options: 'rw,nosuid,nodev,noexec'
-os_mnt_var_log_audit_filesystem: "ext4"
+os_mnt_var_log_audit_filesystem: ""
+os_mnt_var_log_audit_dump: ""
+os_mnt_var_log_audit_passno: ""
 
 os_mnt_var_tmp_dir_mode: '1777'
 os_mnt_var_tmp_enabled: false
 os_mnt_var_tmp_src: ""
 os_mnt_var_tmp_options: 'rw,nosuid,nodev,noexec'
-os_mnt_var_tmp_filesystem: "ext4"
+os_mnt_var_tmp_filesystem: ""
+os_mnt_var_tmp_dump: ""
+os_mnt_var_tmp_passno: ""
 
 #
 # .netrc User whitelist

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -11,3 +11,9 @@
 - name: Reload systemd
   systemd:
     daemon_reload: true
+
+- name: remount fs
+  mount:
+    path: "{{ item }}"
+    state: remounted
+  loop: "{{ mountpoints_changed }}"

--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -12,7 +12,7 @@
   systemd:
     daemon_reload: true
 
-- name: remount fs
+- name: Remount filesystems
   mount:
     path: "{{ item }}"
     state: remounted

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -83,7 +83,7 @@
 
 - name: generate list of current available mounted filesystems on the system
   set_fact:
-    mountpoints_list: "{{ ansible_mounts | map(attribute='mount') | list}}"
+    mountpoints_list: "{{ ansible_mounts | map(attribute='mount') | list }}"
 
 - name: append special devices list to valid mountpoint list
   set_fact:

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -81,194 +81,26 @@
     opts: '{{ proc_mnt_options }}'
     state: mounted
 
-- name: Check if boot exists
-  stat:
-    path: /boot
-  register: boot_exists
+- name: generate list of current available mounted filesystems on the system
+  set_fact:
+    mountpoints_list: "{{ ansible_mounts | map(attribute='mount') | list}}"
 
-- name: Mount /boot with hardened options
-  mount:
-    path: /boot
-    src: '{{ os_mnt_boot_src }}'
-    fstype: '{{ os_mnt_boot_filesystem }}'
-    opts: '{{ os_mnt_boot_options }}'
-    state: present
-  register: bootmount
-  when:
-    - os_mnt_boot_enabled | bool
-    - boot_exists.stat.exists | bool
+- name: append special devices list to valid mountpoint list
+  set_fact:
+    mountpoints_list: "{{ mountpoints_list + ['/dev', '/dev/shm', '/run'] }}"
 
-- name: Harden permissions for /boot directory
-  file:
-    dest: /boot
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_boot_dir_mode }}'
-  when:  boot_exists.stat.exists | bool
-
-- name: Mount /dev with hardened options
-  mount:
-    path: /dev
-    src: '{{ os_mnt_dev_src }}'
-    fstype: '{{ os_mnt_dev_filesystem }}'
-    opts: '{{ os_mnt_dev_options }}'
-    state: present
-  register: devmount
-  when: os_mnt_dev_enabled | bool
-
-- name: Harden permissions for /dev directory
-  file:
-    dest: /dev
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_dev_dir_mode }}'
-
-- name: Mount /dev/shm with hardened options
-  mount:
-    path: /dev/shm
-    src: '{{ os_mnt_dev_shm_src }}'
-    fstype: '{{ os_mnt_dev_shm_filesystem }}'
-    opts: '{{ os_mnt_dev_shm_options }}'
-    state: present
-  register: devshmmount
-  when: os_mnt_dev_shm_enabled | bool
-
-- name: Harden permissions for /dev/shm directory
-  file:
-    dest: /dev/shm
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_dev_shm_dir_mode }}'
-
-- name: Mount /home with hardened options
-  mount:
-    path: /home
-    src: '{{ os_mnt_home_src }}'
-    fstype: '{{ os_mnt_home_filesystem }}'
-    opts: '{{ os_mnt_home_options }}'
-    state: present
-  register: homemount
-  when: os_mnt_home_enabled | bool
-
-- name: Harden permissions for /home directory
-  file:
-    dest: /home
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_home_dir_mode }}'
-
-- name: Mount /run with hardened options
-  mount:
-    path: /run
-    src: '{{ os_mnt_run_src }}'
-    fstype: '{{ os_mnt_run_filesystem }}'
-    opts: '{{ os_mnt_run_options }}'
-    state: present
-  register: runmount
-  when: os_mnt_run_enabled | bool
-
-- name: Harden permissions for /run directory
-  file:
-    dest: /run
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_run_dir_mode }}'
-
-- name: Mount /var with hardened options
-  mount:
-    path: /var
-    src: '{{ os_mnt_var_src }}'
-    fstype: '{{ os_mnt_var_filesystem }}'
-    opts: '{{ os_mnt_var_options }}'
-    state: present
-  register: varmount
-  when: os_mnt_var_enabled | bool
-
-- name: Harden permissions for /var directory
-  file:
-    dest: /var
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_var_dir_mode }}'
-
-- name: Mount /var/log with hardened options
-  mount:
-    path: /var/log
-    src: '{{ os_mnt_var_log_src }}'
-    fstype: '{{ os_mnt_var_log_filesystem }}'
-    opts: '{{ os_mnt_var_log_options }}'
-    state: present
-  register: varlogmount
-  when: os_mnt_var_log_enabled | bool
-
-- name: Harden permissions for /var/log directory
-  file:
-    dest: /var/log
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_var_log_dir_mode }}'
-
-- name: Check if /var/log/audit exists
-  stat:
-    path: /var/log/audit
-  register: var_log_audit_exists
-
-- name: Mount /var/log/audit with hardened options
-  mount:
-    path: /var/log/audit
-    src: '{{ os_mnt_var_log_audit_src }}'
-    fstype: '{{ os_mnt_var_log_audit_filesystem }}'
-    opts: '{{ os_mnt_var_log_audit_options }}'
-    state: present
-  register: varlogauditmount
-  when:
-    - os_mnt_var_log_audit_enabled | bool
-    - var_log_audit_exists.stat.exists | bool
-    - os_auditd_enabled | bool
-
-- name: Harden permissions for /var/log/audit directory
-  file:
-    dest: /var/log/audit
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_var_log_audit_dir_mode }}'
-  when:
-    - os_mnt_var_log_audit_enabled | bool
-    - var_log_audit_exists.stat.exists | bool
-    - os_auditd_enabled | bool
-
-- name: Mount /var/tmp with hardened options
-  mount:
-    path: /var/tmp
-    src: '{{ os_mnt_var_tmp_src }}'
-    fstype: '{{ os_mnt_var_tmp_filesystem }}'
-    opts: '{{ os_mnt_var_tmp_options }}'
-    state: present
-  register: vartmpmount
-  when: os_mnt_var_tmp_enabled | bool
-
-- name: Harden permissions for /var/tmp directory
-  file:
-    dest: /var/tmp
-    owner: 'root'
-    group: 'root'
-    mode: '{{ os_mnt_var_tmp_dir_mode }}'
-
-- name: remount all changed mountpoints
-  mount:
-    path: "{{ item.path }}"
-    src: "{{ item.src }}"
-    fstype: "{{ item.fstype }}"
-    opts: "{{ item.opts }}"
-    state: remounted
-  when: item.when | bool
+- name: minimize access fs
+  include_tasks: minimize_access_fs.yml
   loop:
-    - { path: '/boot', src: '{{ os_mnt_boot_src }}', fstype: '{{ os_mnt_boot_filesystem }}', opts: '{{ os_mnt_boot_options }}', when: "{{ bootmount.changed }}" }
-    - { path: '/dev', src: '{{ os_mnt_dev_src }}', fstype: '{{ os_mnt_dev_filesystem }}', opts: '{{ os_mnt_dev_options }}', when: "{{ devmount.changed }}" }
-    - { path: '/dev/shm', src: '{{ os_mnt_dev_shm_src }}', fstype: '{{ os_mnt_dev_shm_filesystem }}', opts: '{{ os_mnt_dev_shm_options }}', when: "{{ devshmmount.changed }}" }
-    - { path: '/home', src: '{{ os_mnt_home_src }}', fstype: '{{ os_mnt_home_filesystem }}', opts: '{{ os_mnt_home_options }}', when: "{{ homemount.changed }}" }
-    - { path: '/run', src: '{{ os_mnt_run_src }}', fstype: '{{ os_mnt_run_filesystem }}', opts: '{{ os_mnt_run_options }}', when: "{{ runmount.changed }}" }
-    - { path: '/var', src: '{{ os_mnt_var_src }}', fstype: '{{ os_mnt_var_filesystem }}', opts: '{{ os_mnt_var_options }}', when: "{{ varmount.changed }}" }
-    - { path: '/var/log', src: '{{ os_mnt_var_log_src }}', fstype: '{{ os_mnt_var_log_filesystem }}', opts: '{{ os_mnt_var_log_options }}', when: "{{ varlogmount.changed }}" }
-    - { path: '/var/log/audit', src: '{{ os_mnt_var_log_audit_src }}', fstype: '{{ os_mnt_var_log_audit_filesystem }}', opts: '{{ os_mnt_var_log_audit_options }}', when: "{{ varlogauditmount.changed }}" }
-    - { path: '/var/tmp', src: '{{ os_mnt_var_tmp_src }}', fstype: '{{ os_mnt_var_tmp_filesystem }}', opts: '{{ os_mnt_var_tmp_options }}', when: "{{ vartmpmount.changed }}" }
+    - { path: '/boot', src: '{{ os_mnt_boot_src }}', fstype: '{{ os_mnt_boot_filesystem }}', opts: '{{ os_mnt_boot_options }}', enabled: "{{ os_mnt_boot_enabled }}", mode: "{{ os_mnt_boot_dir_mode }}", dump: "{{ os_mnt_boot_dump }}", passno: "{{ os_mnt_boot_passno }}" }
+    - { path: '/dev', src: '{{ os_mnt_dev_src }}', fstype: '{{ os_mnt_dev_filesystem }}', opts: '{{ os_mnt_dev_options }}', enabled: "{{ os_mnt_dev_enabled }}", mode: "{{ os_mnt_dev_dir_mode }}", dump: "{{ os_mnt_dev_dump }}", passno: "{{ os_mnt_dev_passno }}" }
+    - { path: '/dev/shm', src: '{{ os_mnt_dev_shm_src }}', fstype: '{{ os_mnt_dev_shm_filesystem }}', opts: '{{ os_mnt_dev_shm_options }}', enabled: "{{ os_mnt_dev_shm_enabled }}", mode: "{{ os_mnt_dev_shm_dir_mode }}", dump: "{{ os_mnt_dev_shm_dump }}", passno: "{{ os_mnt_dev_shm_passno }}" }
+    - { path: '/home', src: '{{ os_mnt_home_src }}', fstype: '{{ os_mnt_home_filesystem }}', opts: '{{ os_mnt_home_options }}', enabled: "{{ os_mnt_home_enabled }}", mode: "{{ os_mnt_home_dir_mode }}", dump: "{{ os_mnt_home_dump }}", passno: "{{ os_mnt_home_passno }}" }
+    - { path: '/run', src: '{{ os_mnt_run_src }}', fstype: '{{ os_mnt_run_filesystem }}', opts: '{{ os_mnt_run_options }}', enabled: "{{ os_mnt_run_enabled }}", mode: "{{ os_mnt_run_dir_mode }}", dump: "{{ os_mnt_run_dump }}", passno: "{{ os_mnt_run_passno }}" }
+    - { path: '/tmp', src: '{{ os_mnt_tmp_src }}', fstype: '{{ os_mnt_tmp_filesystem }}', opts: '{{ os_mnt_tmp_options }}', enabled: "{{ os_mnt_tmp_enabled }}", mode: "{{ os_mnt_tmp_dir_mode }}", dump: "{{ os_mnt_tmp_dump }}", passno: "{{ os_mnt_tmp_passno }}" }
+    - { path: '/var', src: '{{ os_mnt_var_src }}', fstype: '{{ os_mnt_var_filesystem }}', opts: '{{ os_mnt_var_options }}', enabled: "{{ os_mnt_var_enabled }}", mode: "{{ os_mnt_var_dir_mode }}", dump: "{{ os_mnt_var_dump }}", passno: "{{ os_mnt_var_passno }}" }
+    - { path: '/var/log', src: '{{ os_mnt_var_log_src }}', fstype: '{{ os_mnt_var_log_filesystem }}', opts: '{{ os_mnt_var_log_options }}', enabled: "{{ os_mnt_var_log_enabled }}", mode: "{{ os_mnt_var_log_dir_mode }}", dump: "{{ os_mnt_var_log_dump }}", passno: "{{ os_mnt_var_log_passno }}" }
+    - { path: '/var/log/audit', src: '{{ os_mnt_var_log_audit_src }}', fstype: '{{ os_mnt_var_log_audit_filesystem }}', opts: '{{ os_mnt_var_log_audit_options }}', enabled: "{{ os_mnt_var_log_audit_enabled }}", mode: "{{ os_mnt_var_log_audit_dir_mode }}", dump: "{{ os_mnt_var_log_audit_dump }}", passno: "{{ os_mnt_var_log_audit_passno }}" }
+    - { path: '/var/tmp', src: '{{ os_mnt_var_tmp_src }}', fstype: '{{ os_mnt_var_tmp_filesystem }}', opts: '{{ os_mnt_var_tmp_options }}', enabled: "{{ os_mnt_var_tmp_enabled }}", mode: "{{ os_mnt_var_tmp_dir_mode }}", dump: "{{ os_mnt_var_tmp_dump }}", passno: "{{ os_mnt_var_tmp_passno }}" }
+  loop_control:
+    loop_var: mount

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -81,15 +81,15 @@
     opts: '{{ proc_mnt_options }}'
     state: mounted
 
-- name: generate list of current available mounted filesystems on the system
+- name: Generate list of current available mounted filesystems on the system
   set_fact:
     mountpoints_list: "{{ ansible_mounts | map(attribute='mount') | list }}"
 
-- name: append special devices list to valid mountpoint list
+- name: Append special devices list to valid mountpoint list
   set_fact:
     mountpoints_list: "{{ mountpoints_list + ['/dev', '/dev/shm', '/run'] }}"
 
-- name: minimize access fs
+- name: Minimize access for filesystems
   include_tasks: minimize_access_fs.yml
   loop:
     - { path: '/boot', src: '{{ os_mnt_boot_src }}', fstype: '{{ os_mnt_boot_filesystem }}', opts: '{{ os_mnt_boot_options }}', enabled: "{{ os_mnt_boot_enabled }}", mode: "{{ os_mnt_boot_dir_mode }}", dump: "{{ os_mnt_boot_dump }}", passno: "{{ os_mnt_boot_passno }}" }

--- a/roles/os_hardening/tasks/minimize_access_fs.yml
+++ b/roles/os_hardening/tasks/minimize_access_fs.yml
@@ -1,0 +1,36 @@
+---
+- name: "Configure mount {{ mount.path }} with hardened options"
+  mount:
+    path: "{{ mount.path }}"
+    src: "{{ mount.src | default(mountinfo.device, true) }}"
+    fstype: "{{ mount.fstype | default(mountinfo.fstype, true) }}"
+    opts: "{{ mount.opts }}"
+    dump: "{{ mount.dump | default('1' if mount.fstype | default(mountinfo.fstype, true) in ['ext3', 'ext4'] else '0', true) }}"
+    passno: "{{ mount.passno | default('2' if mount.fstype | default(mountinfo.fstype, true) in ['ext3', 'ext4'] else '0', true) }}"
+    state: present
+  register: mountpoint
+  when:
+    - mount.enabled | bool
+    - mount.path in mountpoints_list
+  vars:
+    mountinfo: "{{ ansible_mounts | selectattr('mount', 'equalto', mount.path) | list | first | default(None) }}"
+  notify: remount fs
+
+- name: "Check if {{ mount.path }} exists"
+  stat:
+    path: "{{ mount.path }}"
+  register: mountpoint_exists
+
+- name: "Harden permissions for {{ mount.path }} directory"
+  file:
+    dest: "{{ mount.path }}"
+    owner: 'root'
+    group: 'root'
+    mode: "{{ mount.mode }}"
+  when:
+    - mountpoint_exists.stat.exists | bool
+
+- name: "Register changed mountpoints"
+  set_fact:
+    mountpoints_changed: "{{ mountpoints_changed | default([]) + [mount.path] }}"
+  when: mountpoint.changed

--- a/roles/os_hardening/tasks/minimize_access_fs.yml
+++ b/roles/os_hardening/tasks/minimize_access_fs.yml
@@ -14,7 +14,7 @@
     - mount.path in mountpoints_list
   vars:
     mountinfo: "{{ ansible_mounts | selectattr('mount', 'equalto', mount.path) | list | first | default(None) }}"
-  notify: remount fs
+  notify: Remount filesystems
 
 - name: "Check if {{ mount.path }} exists"
   stat:
@@ -33,4 +33,4 @@
 - name: "Register changed mountpoints"
   set_fact:
     mountpoints_changed: "{{ mountpoints_changed | default([]) + [mount.path] }}"
-  when: mountpoint.changed # noqa no-handler
+  when: mountpoint.changed  # noqa no-handler

--- a/roles/os_hardening/tasks/minimize_access_fs.yml
+++ b/roles/os_hardening/tasks/minimize_access_fs.yml
@@ -33,4 +33,4 @@
 - name: "Register changed mountpoints"
   set_fact:
     mountpoints_changed: "{{ mountpoints_changed | default([]) + [mount.path] }}"
-  when: mountpoint.changed
+  when: mountpoint.changed # noqa no-handler


### PR DESCRIPTION
-  removed a lot duplicated code by using a loop
-  added new hardening options for /tmp
-  added new options "passno" and "dump" for every filesystem.
   currently ansible changed that values to 0 for every fs
   new default depends on fstype, can be overwritten in config
-  removed default fstype in config
   the type will now be autodetected,  can be overwritten in config
-  mount src setting is now optional
   the source will now be autodetected,  can be overwritten in config
-  it will be now checked, if it is really a mount
-  changed fs reload to handler
-  removed check os_auditd_enabled on /var/log/audit

Notes:
-  The playbook will no longer fail, if a folder does not exists
-  It will now skip mount points, if they are not present on the target system.
   If you have many different configured servers this is very useful
-  The folders are still be hardened regardless if *_enabled  is used or not
-  Was there a reason why /var/log/audit was only hardened, when the os_auditd_enabled variable was set to true?