### PR TITLE
change default to allow SFTP

### DIFF
--- a/molecule/ssh_hardening/converge.yml
+++ b/molecule/ssh_hardening/converge.yml
@@ -10,3 +10,5 @@
   tasks:
     - include_role:
         name: ssh_hardening
+  vars:
+    sftp_enabled: false

--- a/molecule/ssh_hardening_custom_tests/converge.yml
+++ b/molecule/ssh_hardening_custom_tests/converge.yml
@@ -48,7 +48,6 @@
     ssh_print_last_log: true
     ssh_banner: true
     ssh_server_password_login: true
-    sftp_enabled: true
     sftp_chroot: true
     # ssh_server_enabled: false
     ssh_server_ports:

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -274,7 +274,7 @@ Example playbook:
 
 ## After using the role Ansibles template/copy/file module does not work anymore
 
-If you use this role to disable SFTP (`stfp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files. If your control node uses OpenSSH version 8.8 or above, you also need to set `scp_extra_args = "-O"`, since starting with that version the `scp` utility also defaults to using SFTP.
+If you use this role to disable SFTP (`sftp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files. If your control node uses OpenSSH version 8.8 or above, you also need to set `scp_extra_args = "-O"`, since starting with that version the `scp` utility also defaults to using SFTP.
 
 ## Changing the default port and idempotency
 

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -274,7 +274,7 @@ Example playbook:
 
 ## After using the role Ansibles template/copy/file module does not work anymore
 
-If you use this role to disable SFTP (`sftp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files. If your control node uses OpenSSH version 8.8 or above, you also need to set `scp_extra_args = "-O"`, since starting with that version the `scp` utility also defaults to using SFTP.
+If you use this role to disable SFTP (`sftp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files. If your control node uses OpenSSH version 9.0 or above, you also need to set `scp_extra_args = "-O"`, since starting with that version the `scp` utility also defaults to using SFTP.
 
 ## Changing the default port and idempotency
 

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -272,6 +272,10 @@ Example playbook:
       - "AcceptEnv LANG"
 ```
 
+## After using the role Ansibles template/copy/file module does not work anymore
+
+If you use this role to disable SFTP (`stfp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files.
+
 ## Changing the default port and idempotency
 
 This role uses the default port 22 or the port configured in the inventory to connect to the server. If the default `ssh` port is changed via `ssh_server_ports`, once the ssh server is restarted, it will still try to connect using the previous port. In order to run this role again on the same server the inventory will have to be updated to use the new ssh port.

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -126,8 +126,8 @@ As this role requires root-privileges, we added `become: true` to all tasks. So 
   - Default: `false`
   - Description: false to disable display of last login information.
 - `sftp_enabled`
-  - Default: `false`
-  - Description: true to enable sftp configuration.
+  - Default: `true`
+  - Description: false to disable sftp configuration.
 - `sftp_umask`
   - Default: `'0027'`
   - Description: Specifies the umask for sftp.

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -274,7 +274,7 @@ Example playbook:
 
 ## After using the role Ansibles template/copy/file module does not work anymore
 
-If you use this role to disable SFTP (`stfp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files.
+If you use this role to disable SFTP (`stfp_enabled: false`) you will get errors. Ansible uses by default SFTP to transfer files to the remote hosts. You have to set `scp_if_ssh = True` in your ansible.cfg. This way Ansible uses SCP to copy files. If your control node uses OpenSSH version 8.8 or above, you also need to set `scp_extra_args = "-O"`, since starting with that version the `scp` utility also defaults to using SFTP.
 
 ## Changing the default port and idempotency
 

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -158,8 +158,8 @@ ssh_banner_path: '/etc/ssh/banner.txt'
 # false to disable distribution version leakage during initial protocol handshake
 ssh_print_debian_banner: false      # sshd (Debian OS family only)
 
-# true to enable sftp configuration
-sftp_enabled: false
+# false to disable sftp configuration
+sftp_enabled: true
 
 # false to disable sftp chroot
 sftp_chroot: true


### PR DESCRIPTION
Historically we have disabled SFTP with the argument, that running less services is more secure.

I want to change that, because OpenSSH advises to use SFTP ([release notes of OpenSSH 8.0](https://lists.mindrot.org/pipermail/openssh-unix-announce/2019-April/000136.html)).

> The scp protocol is outdated, inflexible and not readily fixed. We
recommend the use of more modern protocols like sftp and rsync for
file transfer instead.

Additionally disabling STFP generates errors with Ansible in the default configuration