### PR TITLE
add centos >8 Support

### DIFF
--- a/roles/ssh_hardening/vars/CentOS_8.yml
+++ b/roles/ssh_hardening/vars/CentOS_8.yml
@@ -1,0 +1,23 @@
+---
+sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
+sshd_service_name: sshd
+ssh_owner: root
+ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'ssh_keys'
+ssh_selinux_packages:
+  - policycoreutils-python-utils
+  - checkpolicy
+
+# true if SSH support Kerberos
+ssh_kerberos_support: true
+
+# true if SSH has PAM support
+ssh_pam_support: true
+
+sshd_moduli_file: '/etc/ssh/moduli'
+
+# disable CRYPTO_POLICY to take settings from sshd configuration
+# see: https://access.redhat.com/solutions/4410591
+sshd_disable_crypto_policy: true

--- a/roles/ssh_hardening/vars/CentOS_9.yml
+++ b/roles/ssh_hardening/vars/CentOS_9.yml
@@ -1,0 +1,23 @@
+---
+sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: '/etc/ssh'
+sshd_service_name: sshd
+ssh_owner: root
+ssh_group: root
+ssh_host_keys_owner: 'root'
+ssh_host_keys_group: 'ssh_keys'
+ssh_selinux_packages:
+  - policycoreutils-python-utils
+  - checkpolicy
+
+# true if SSH support Kerberos
+ssh_kerberos_support: true
+
+# true if SSH has PAM support
+ssh_pam_support: true
+
+sshd_moduli_file: '/etc/ssh/moduli'
+
+# disable CRYPTO_POLICY to take settings from sshd configuration
+# see: https://access.redhat.com/solutions/4410591
+sshd_disable_crypto_policy: true


### PR DESCRIPTION
As of CentOS 8, the `policycoreutils-python` package has been renamed to `policycoreutils-python-utils`. Article about it: <https://techglimpse.com/cant-install-policycoreutils-python-rhel-centos-8/>