### PR TITLE
rewrite of "user_accounts" task for linux hardening 

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -229,16 +229,13 @@ We know that this is the case on Raspberry Pi.
   - Description: Specify system accounts whose login should not be disabled and password not changed
 - `os_ignore_home_folder_users`
   - Default: `[]`
-  - Description: Specify user accounts, whose home folders shouldn't be chmodded to 700. 
-- `os_chmod_rootuser_home`
+  - Description: Specify user accounts, whose home folders shouldn't be chmodded to 700 when "os_chmod_home_folders" is enabled. 
+- `os_chmod_rootuser_home_folder`
   - Default: `true`
   - Description: Set to `false` to disable "chmod 700" of root's home folder
 - `os_chmod_home_folders`
   - Default: `true`
   - Description: Set to `false` to disable "chmod 700" of home folders for regular users
-- `os_ignore_home_folder_users`
-  - Default: `[]`
-  - Description: Specify user accounts, whose home folders are ignored when "os_chmod_home_folders" is enabled. 
 - `os_cron_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring cron.
@@ -260,6 +257,9 @@ We know that this is the case on Raspberry Pi.
 - `os_remove_additional_root_users`
   - Default: `false`
   - Description: When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted.
+- `os_users_without_password_ageing`
+  - Default: `[]`
+  - Description: List of users, where password ageing should not enforced
 - `os_minimize_access_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring minimize_access.

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -228,8 +228,14 @@ We know that this is the case on Raspberry Pi.
   - Default: `['vagrant', 'kitchen']`
   - Description: Specify system accounts whose login should not be disabled and password not changed
 - `os_ignore_home_folder_users`
-  - Default: `lost+found`
-  - Description: specify user home folders in `/home` that shouldn't be chmodded to 700
+  - Default: `[]`
+  - Description: Specify user accounts, whose home folders shouldn't be chmodded to 700. 
+- `os_chmod_home_folders`
+  - Default: `true`
+  - Description: Set to `false` to disable "chmod 700" of home folders for regular users
+- `os_ignore_home_folder_users`
+  - Default: `[]`
+  - Description: Specify user accounts, whose home folders are ignored when "os_chmod_home_folders" is enabled. 
 - `os_cron_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring cron.

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -230,6 +230,9 @@ We know that this is the case on Raspberry Pi.
 - `os_ignore_home_folder_users`
   - Default: `[]`
   - Description: Specify user accounts, whose home folders shouldn't be chmodded to 700. 
+- `os_chmod_rootuser_home`
+  - Default: `true`
+  - Description: Set to `false` to disable "chmod 700" of root's home folder
 - `os_chmod_home_folders`
   - Default: `true`
   - Description: Set to `false` to disable "chmod 700" of home folders for regular users
@@ -251,6 +254,12 @@ We know that this is the case on Raspberry Pi.
 - `os_user_pw_ageing`
   - Default: `true`
   - Description: Set to false to disable password age enforcement on existing users
+- `os_rootuser_pw_ageing`
+  - Default: `false`
+  - Description: Set to true to enforce password age settings for root user(s)
+- `os_remove_additional_root_users`
+  - Default: `false`
+  - Description: When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted.
 - `os_minimize_access_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring minimize_access.

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -247,7 +247,10 @@ We know that this is the case on Raspberry Pi.
   - Description: Set to false to disable installing and configuring limits.
 - `os_login_defs_enabled`
   - Default: `true`
-  - Description: Set to false to disable installing and configuring login_defs.
+  - Description: Set to false to disable installing and configuring login_defs for newly created users.
+- `os_user_pw_ageing`
+  - Default: `true`
+  - Description: Set to false to disable password age enforcement on existing users
 - `os_minimize_access_enabled`
   - Default: `true`
   - Description: Set to false to disable installing and configuring minimize_access.

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -16,7 +16,7 @@ os_auth_root_ttys: [console, tty1, tty2, tty3, tty4, tty5, tty6]
 os_chfn_restrict: ''
 
 # Set to false to disable chmod userhome folders to 700
-os_chmod_rootuser_home: true
+os_chmod_rootuser_home_folder: true
 os_chmod_home_folders: true
 
 # Specify names of user, where home folders shouldn't be chmodded to 700
@@ -352,7 +352,7 @@ os_rootuser_pw_ageing: false
 os_remove_additional_root_users: false
 
 #List of users, where password ageing should not enforced
-users_without_password_ageing: []
+os_users_without_password_ageing: []
 
 # Set to false to disable installing and configuring minimize_access.
 os_minimize_access_enabled: true

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -15,13 +15,16 @@ os_auth_root_ttys: [console, tty1, tty2, tty3, tty4, tty5, tty6]
 
 os_chfn_restrict: ''
 
-# Set to false to disable chmod /home folders to 700
+# Set to false to disable chmod userhome folders to 700
+os_chmod_rootuser_home: true
 os_chmod_home_folders: true
+
+# Specify names of user, where home folders shouldn't be chmodded to 700
+os_ignore_home_folder_users: []
 
 # May contain: change_user
 os_security_users_allow: []
-# Specify user home folders in /home that shouldn't be chmodded to 700
-os_ignore_home_folder_users: ['lost+found']
+
 # Specify system accounts whose login should not be disabled and password not changed
 os_ignore_users: ['vagrant', 'kitchen']
 os_security_kernel_enable_module_loading: true

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -341,8 +341,13 @@ os_ctrlaltdel_disabled: false
 # Set to false to disable installing and configuring limits.
 os_limits_enabled: true
 
-# Set to false to disable installing and configuring login_defs.
+# Set to false to disable installing and configuring login_defs for newly created users.
 os_login_defs_enabled: true
+
+# Set to false to disable password age enforcement on existing users
+os_user_pw_ageing: true
+#List of users, where password ageing should not enforced
+users_without_password_ageing: []
 
 # Set to false to disable installing and configuring minimize_access.
 os_minimize_access_enabled: true

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -346,6 +346,11 @@ os_login_defs_enabled: true
 
 # Set to false to disable password age enforcement on existing users
 os_user_pw_ageing: true
+os_rootuser_pw_ageing: false
+
+# When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted.
+os_remove_additional_root_users: false
+
 #List of users, where password ageing should not enforced
 users_without_password_ageing: []
 

--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -38,10 +38,6 @@
   tags: limits
   when: os_limits_enabled | bool
 
-- import_tasks: login_defs.yml
-  tags: login_defs
-  when: os_login_defs_enabled | bool
-
 - import_tasks: minimize_access.yml
   tags: minimize_access
   when: os_minimize_access_enabled | bool

--- a/roles/os_hardening/tasks/login_defs.yml
+++ b/roles/os_hardening/tasks/login_defs.yml
@@ -1,8 +1,0 @@
----
-- name: Create login.defs | os-05, os-05b
-  template:
-    src: 'etc/login.defs.j2'
-    dest: '/etc/login.defs'
-    owner: 'root'
-    group: 'root'
-    mode: '0444'

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -62,7 +62,7 @@
   loop: "{{ regular_users }}"
   when: 
     - os_user_pw_ageing
-    - item not in users_without_password_ageing
+    - item not in os_users_without_password_ageing
 
 - name: extract root account(s) from local user database
   loop: "{{ getent_passwd.keys()|list }}"
@@ -89,7 +89,7 @@
     state: directory
   loop: "{{ root_users }}"
   when: 
-    - os_chmod_rootuser_home | bool
+    - os_chmod_rootuser_home_folder | bool
 
 - name: Set password ageing for root user(s)
   user:

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -17,7 +17,7 @@
 
 - name: extract system accounts from local user database
   loop: "{{ getent_passwd.keys()|list }}"
-  when:
+  when:  
     - getent_passwd[item][1]|int > 0
     - getent_passwd[item][1]|int <= os_auth_sys_uid_max|int
     - item is not in os_always_ignore_users     # skip users from "os_always_ignore_users" list (taken from role "vars")
@@ -33,19 +33,23 @@
     createhome: false
   loop: "{{ system_users }}"
 
-- name: get all home directories in /home, but skip ignored users
-  find:
-    paths: /home/
-    recurse: false
-    file_type: directory
-    excludes: "{{ os_ignore_home_folder_users | join(',') }}"
-  register: home_directories
-  when: os_chmod_home_folders | bool
+- name: extract regular (non-system) accounts from local user database
+  loop: "{{ getent_passwd.keys()|list }}"
+  when:  
+    - getent_passwd[item][1]|int >= os_auth_uid_min|int
+    - getent_passwd[item][1]|int <= os_auth_uid_max|int
+    - item is not in os_always_ignore_users     # skip users from "os_always_ignore_users" list (taken from role "vars")
+    - item is not in os_ignore_users            # skip users from "os_ignore_users"        list (taken from role "defaults")
+  set_fact:
+    regular_users: "{{ regular_users|default([]) + [item] }}"
 
-- name: set ownership of /home directories to 0700
+- name: set ownership of user home directories to 0700
   file:
     mode: 0700
-    path: "{{ item.path }}"
+    owner: "{{ item }}"
+    path: "{{ getent_passwd[item][4] }}"
     state: directory
-  loop: "{{ home_directories.files }}"
-  when: os_chmod_home_folders | bool
+  loop: "{{ regular_users }}"
+  when: 
+    - os_chmod_home_folders | bool
+    - item not in os_ignore_home_folder_users|default([])

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -53,3 +53,13 @@
   when: 
     - os_chmod_home_folders | bool
     - item not in os_ignore_home_folder_users|default([])
+
+- name: Set password ageing for exisiting regular user accounts (system users have no password)
+  user:
+    name: "{{ item }}"
+    password_expire_min: "{{ os_auth_pw_min_age }}"
+    password_expire_max: "{{ os_auth_pw_max_age }}"
+  loop: "{{ regular_users }}"
+  when: 
+    - os_user_pw_ageing
+    - item not in users_without_password_ageing

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -63,3 +63,38 @@
   when: 
     - os_user_pw_ageing
     - item not in users_without_password_ageing
+
+- name: extract root account(s) from local user database
+  loop: "{{ getent_passwd.keys()|list }}"
+  when:  
+    - getent_passwd[item][1]|int == 0
+  set_fact:
+    root_users: "{{ root_users|default([]) + [item] }}"
+
+- name: Remove non-root users with UID=0
+  user:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ root_users }}"
+  when: 
+    - os_remove_additional_root_users|bool
+    - root_users|length > 1
+    - item != "root"
+
+- name: set ownership of root user home directory(s) to 0700
+  file:
+    mode: 0700
+    owner: "{{ item }}"
+    path: "{{ getent_passwd[item][4] }}"
+    state: directory
+  loop: "{{ root_users }}"
+  when: 
+    - os_chmod_rootuser_home | bool
+
+- name: Set password ageing for root user(s)
+  user:
+    name: "{{ item }}"
+    password_expire_min: "{{ os_auth_pw_min_age }}"
+    password_expire_max: "{{ os_auth_pw_max_age }}"
+  loop: "{{ root_users }}"
+  when: os_rootuser_pw_ageing|bool

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -9,44 +9,29 @@
   when: os_login_defs_enabled | bool
   tags: login_defs
 
-- name: Calculate UID_MAX from UID_MIN by substracting 1
-  set_fact:
-    uid_max: '{{ uid_min.stdout | int - 1 }}'
-  when: uid_min.stdout|int > 0
+- name: Read local linux user database
+  getent:
+    database: passwd
+    #creates a dict for each user containing UID/HOMEDIR etc...
+  when: getent_passwd is undefined # skip this task if "getent" has run before
 
-- name: Set UID_MAX on Debian-systems if no login.defs exist
-  set_fact:
-    uid_max: '999'
+- name: extract system accounts from local user database
+  loop: "{{ getent_passwd.keys()|list }}"
   when:
-    - ansible_facts.os_family == 'Debian'
-    - uid_max is not defined
-
-- name: Set UID_MAX on other systems if no login.defs exist
+    - getent_passwd[item][1]|int > 0
+    - getent_passwd[item][1]|int <= os_auth_sys_uid_max|int
+    - item is not in os_always_ignore_users     # skip users from "os_always_ignore_users" list (taken from role "vars")
+    - item is not in os_ignore_users            # skip users from "os_ignore_users"        list (taken from role "defaults")
   set_fact:
-    uid_max: '499'
-  when: uid_max is not defined
+    system_users: "{{ system_users|default([]) + [item] }}"
 
-- name: Get all system accounts
-  command: awk -F'':'' '{ if ( $3 <= {{ uid_max|quote }} ) print $1}' /etc/passwd
-  args:
-    removes: /etc/passwd
-  changed_when: false
-  check_mode: false
-  register: sys_accs
-
-- name: Remove always ignored system accounts from list
-  set_fact:
-    sys_accs_cond: '{{ sys_accs.stdout_lines | difference(os_always_ignore_users) }}'
-  check_mode: false
-
-- name: Change system accounts not on the user provided ignore-list
+- name: remove shell+password for linux system accounts
   user:
     name: '{{ item }}'
     shell: '{{ os_nologin_shell_path }}'
     password: '*'
     createhome: false
-  with_community.general.flattened:
-    - '{{ sys_accs_cond | default([]) | difference(os_ignore_users) | list }}'
+  loop: "{{ system_users }}"
 
 - name: get all home directories in /home, but skip ignored users
   find:

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -1,11 +1,13 @@
 ---
-- name: Get UID_MIN from login.defs
-  shell: awk '/^\s*UID_MIN\s*([0-9]*).*?$/ {print $2}' /etc/login.defs
-  args:
-    removes: /etc/login.defs
-  register: uid_min
-  check_mode: false
-  changed_when: false
+- name: Create login.defs | os-05, os-05b
+  template:
+    src: 'etc/login.defs.j2'
+    dest: '/etc/login.defs'
+    owner: 'root'
+    group: 'root'
+    mode: '0444'
+  when: os_login_defs_enabled | bool
+  tags: login_defs
 
 - name: Calculate UID_MAX from UID_MIN by substracting 1
   set_fact:


### PR DESCRIPTION
- fixes #570
- avoids ansible "command" usage of "awk" in favor of "getent passwd" module
- consolidate "login.defs" file handling in one place (the file got modified "login_defs" task. The "user_accounts" task then parsed the file instead of re-using the values used during modification)
- enforces home dir ownership (in addition to folder permissions)
- home dir locations are read from PAM (instead of expecting them to be in "/home/*"). This is more reliable and obsoletes a workaround for the "/home/lost+found" home dir of the non-existing "lost+found" user.
- adds user_account handling for root user

Before merging you might want to spend some extra thoughts on:
- testing (I tested RHEL8 only)
- default values for newly introduced vars and changed existing vars
- deprecation of either `os_always_ignore_users` or `os_ignore_users` variable. They seem to do exactly the same thing..?