### PR TITLE
Add nginx variables for config-path and owner/group

### DIFF
--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -75,6 +75,18 @@ It works with the following nginx-roles, including, but not limited to:
 - [nginx_dh_size][]
   - Default: `2048`
   - Description: Specifies the length of DH parameters for EDH ciphers.
+- [nginx_configuration_dir][]
+  - default: "/etc/nginx"
+  - Description: The main location for all nginx configuration files
+- [nginx_configuration_hardening_dir][]
+  - default: "/etc/nginx"
+  - Description: The location for the nginx hardening configuration file (Could be different e.g. when used in jails)
+- [nginx_owner_user][]
+  - default: "root"
+  - Description: The owner user of the nginx configuration files
+- [nginx_owner_group][]
+  - default: "root"
+  - Description: The owner group of the nginx configuration files
 
 ## Example Playbook
 

--- a/roles/nginx_hardening/defaults/main.yml
+++ b/roles/nginx_hardening/defaults/main.yml
@@ -11,6 +11,10 @@ nginx_client_header_timeout: "10"
 nginx_send_timeout: "10"
 nginx_limit_conn_zone: "$binary_remote_addr zone=default:10m"
 nginx_limit_conn: "default 5"
+nginx_configuration_dir: "/etc/nginx"
+nginx_configuration_hardening_dir: "/etc/nginx"
+nginx_owner_user: "root"
+nginx_owner_group: "root"
 nginx_add_header:
   # avoid clickjacking
   - X-Frame-Options SAMEORIGIN

--- a/roles/nginx_hardening/tasks/main.yml
+++ b/roles/nginx_hardening/tasks/main.yml
@@ -2,76 +2,76 @@
 - name: Create additional configuration
   template:
     src: "hardening.conf.j2"
-    dest: "/etc/nginx/conf.d/90.hardening.conf"
+    dest: "{{ nginx_configuration_dir }}/conf.d/90.hardening.conf"
     mode: '0600'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change configuration in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*server_tokens'
     line: "    server_tokens {{ nginx_server_tokens }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change ssl_protocols in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*ssl_protocols'
     line: "    ssl_protocols {{ nginx_ssl_protocols }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change ssl_prefer_server_ciphers in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*ssl_prefer_server_ciphers'
     line: "    ssl_prefer_server_ciphers {{ nginx_ssl_prefer_server_ciphers }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change client_max_body_size in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*client_max_body_size'
     line: "    client_max_body_size {{ nginx_client_max_body_size }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change client_body_buffer_size in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*client_body_buffer_size'
     line: "    client_body_buffer_size {{ nginx_client_body_buffer_size }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Change keepalive_timeout in main nginx.conf
   lineinfile:
-    dest: "/etc/nginx/nginx.conf"
+    dest: "{{ nginx_configuration_dir }}/nginx.conf"
     regexp: '^\s*keepalive_timeout'
     line: "    keepalive_timeout {{ nginx_keepalive_timeout }};"
     insertafter: "http {"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx
 
 - name: Remove default.conf
@@ -81,14 +81,14 @@
   when: nginx_remove_default_site
   notify: Restart nginx
   loop:
-    - "/etc/nginx/conf.d/default.conf"
-    - "/etc/nginx/sites-enabled/default"
+    - "{{ nginx_configuration_dir }}/conf.d/default.conf"
+    - "{{ nginx_configuration_dir }}/sites-enabled/default"
 
 - name: Generate dh group
   openssl_dhparam:
-    path: "/etc/nginx/dh{{ nginx_dh_size }}.pem"
+    path: "{{ nginx_configuration_dir }}/dh{{ nginx_dh_size }}.pem"
     size: "{{ nginx_dh_size }}"
     mode: '0640'
-    owner: "root"
-    group: "root"
+    owner: "{{ nginx_owner_user }}"
+    group: "{{ nginx_owner_group }}"
   notify: Restart nginx

--- a/roles/nginx_hardening/templates/hardening.conf.j2
+++ b/roles/nginx_hardening/templates/hardening.conf.j2
@@ -11,7 +11,7 @@ limit_conn_zone             {{ nginx_limit_conn_zone }};
 limit_conn                  {{ nginx_limit_conn }};
 ssl_ciphers                 '{{ nginx_ssl_ciphers }}';
 ssl_session_tickets         {{ nginx_ssl_session_tickets }};
-ssl_dhparam                 /etc/nginx/dh{{ nginx_dh_size }}.pem;
+ssl_dhparam                 {{ nginx_configuration_hardening_dir }}/dh{{ nginx_dh_size }}.pem;
 {% for header in nginx_add_header %}
 add_header                  {{ header }};
 {% endfor %}


### PR DESCRIPTION
If you want to use nginx hardening on FreeBSD within jails you need to be able to change the default directories and owner information. 