### PR TITLE
do not manage trusted user ca keys if none exist

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -110,7 +110,9 @@
 
 - name: Include tasks to setup ca keys and principals
   include_tasks: ca_keys_and_principals.yml
-  when: ssh_trusted_user_ca_keys_file | length > 0
+  when:
+    - ssh_trusted_user_ca_keys_file | length > 0
+    - ssh_trusted_user_ca_keys | length > 0
 
 - name: Include selinux specific tasks
   include_tasks: selinux.yml


### PR DESCRIPTION
We are using Okta Advanced Server Access (formerly ScaleFT) and we need to configure sshd with the trusted user ca from Okta.

When setting `ssh_trusted_user_ca_keys_file` to the ca file managed by `sftd` this role overwrites this file every time and sshd is being restarted.

This change disables management of the ca file if no ca keys are set in `ssh_trusted_user_ca_keys`.