### PR TITLE
OpenBSD does not set distributiuon_major_version

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -5,9 +5,9 @@
     name: 'os_vars'
   with_first_found:
     - files:
-        - '{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml'
+        - '{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version | default() }}.yml'
         - '{{ ansible_facts.distribution }}.yml'
-        - '{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml'
+        - '{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version | default() }}.yml'
         - '{{ ansible_facts.os_family }}.yml'
       skip: true
   tags: always


### PR DESCRIPTION
This role fails with `The task includes an option with an undefined variable` on OpenBSD because `distributiuon_major_version` is not set on OpenBSD.

We should either default to "" if the variable is not set, or remove `vars/OpenBSD.yml`. I would prefer the former :)