### PR TITLE
OpenBSD does not support GSSAPI Authentication

### DIFF
--- a/roles/ssh_hardening/templates/openssh.conf.j2
+++ b/roles/ssh_hardening/templates/openssh.conf.j2
@@ -106,10 +106,13 @@ RSAAuthentication yes
 # Disable password-based authentication, it can allow for potentially easier brute-force attacks.
 PasswordAuthentication {{ 'yes' if ssh_client_password_login else 'no' }}
 
+{# OpenBSD does not support GSSAPIAuthentication, so leave this out if on OpenBSD #}
+{% if ansible_facts.os_family != 'OpenBSD' %}
 # Only use GSSAPIAuthentication if implemented on the network.
 GSSAPIAuthentication {{ 'yes' if (ssh_gssapi_support|bool) else 'no' }}
 GSSAPIDelegateCredentials {{ 'yes' if (ssh_gssapi_delegation|bool) else 'no' }}
 
+{% endif %}
 # Disable tunneling
 Tunnel no
 

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -143,10 +143,13 @@ KerberosTicketCleanup yes
 #KerberosGetAFSToken no
 {% endif %}
 
+{# OpenBSD does not support GSSAPIAuthentication, so leave this out if on OpenBSD #}
+{% if ansible_facts.os_family != 'OpenBSD' -%}
 # Only enable GSSAPI authentication if it is configured.
 GSSAPIAuthentication {{ 'yes' if ssh_gssapi_support else 'no' }}
 GSSAPICleanupCredentials yes
 
+{% endif %}
 {% if ssh_deny_users %}
 # In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here.
 # For key-based authentication this is not necessary, since all keys must be explicitely enabled.


### PR DESCRIPTION
Howdy!

OpenBSD does not support GSSAPI Authentication, and is really not happy when GSSAPI-options are present in its configfiles.

This patch reverts the changes made in ed9447a, which sort of ruined the changes introduced in dev-sec/ansible-ssh-hardening/pull/171. It also introduces a new variable, `ssh_gssapi_auth` to enable GSSAPI authentication.

After creating this patch, I realized that this patch will break GSSAPI authentication for anyone who has enabled this today. Today, setting `ssh_gssapi_support` to `true` will enable GSSAPI authentication. After this patch, the same will merely indicate that your system supports GSSAPI authentication. You'll need to set `ssh_gssapi_auth` to `true` to enable GSSAPI authentication.

I believe that this is the most "correct" solution. But as mentioned, it will break GSSAPI authentication for anyone who uses it today.

Another solution is to switch the name of the two options `ssh_gssapi_auth` and `ssh_gssapi_support`, and setting `ssh_gssapi_auth` to true by default. Doing this will not break any current installations using GSSAPI authentication. BUT, it will be semantically confusing to use `ssh_gssapi_auth` to indicate that the system supports GSSAPI authentication, and `ssh_gssapi_support` to turn it on or off.

A third solution could be to simply introduce the conditional `if ansible_os_family != "OpenBSD"` around the GSSAPI-lines in the jinja-templates. This might be the simplest solution.

It is also possible to just drop OpenBSD-support (this is the "do nothing"-solution), but I really want to use this on all my systems, and I'd be happy to contribute the code to get this to work :)

Please let me know what you think of this, and  I'll ammend my patch accordingly.