### PR TITLE
Allow ssh_allow_tcp_forwarding to be a boolean

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -64,7 +64,7 @@ As this role requires root-privileges, we added `become: true` to all tasks. So 
   - Description: Disable root-login. Set to `'without-password'` or `'yes'` to enable root-login - The quotes are required!
 - `ssh_allow_tcp_forwarding`
   - Default: `no`
-  - Description: `'no'` to disable TCP Forwarding. Set to `'yes'` to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you can specify `'yes'`, `'no'`, `'all'`, `'local'`or`'remote'`. <br> _Note_: values passed to this variable must be strings, thus values `'yes'`and`'no'` should be passed with quotes.
+  - Description: `'no'` or `False` to disable TCP Forwarding. Set to `'yes'` or `True` to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you can specify `'yes'`, `'no'`, `'all'`, `'local'`or`'remote'`.
 - `ssh_gateway_ports`
   - Default: `false`
   - Description: `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to.

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -197,9 +197,9 @@ PermitTunnel {{ 'yes' if (ssh_permit_tunnel|bool) else 'no' }}
 # Disable forwarding tcp connections.
 # no real advantage without denied shell access
 {% if sshd_version is version('6.2', '>=') %}
-AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no', 'local', 'all', 'remote')) else 'no' }}
+AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no', 'local', 'all', 'remote')) else ('yes' if (ssh_allow_tcp_forwarding|bool) else 'no') }}
 {% else %}
-AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no')) else 'no' }}
+AllowTcpForwarding {{ ssh_allow_tcp_forwarding if (ssh_allow_tcp_forwarding in ('yes', 'no')) else ('yes' if (ssh_allow_tcp_forwarding|bool) else 'no') }}
 {% endif %}
 
 # Disable agent forwarding, since local agent could be accessed through forwarded connection.


### PR DESCRIPTION
After spending some time trying to figure out why I could not set `ssh_allow_tcp_forwarding: true` I have decided to update the code to allow it. 

This patch will keep supporting all the other use cases, for example it will keep to return "no" for an unknown value.

This has probably bit many people in the past and was also discussed in #330 