### PR TITLE
make number of warning days before user password expires configurable

### DIFF
--- a/molecule/os_hardening/converge.yml
+++ b/molecule/os_hardening/converge.yml
@@ -29,6 +29,7 @@
     os_filesystem_whitelist: []
     os_yum_repo_file_whitelist: ['foo.repo']
     os_users_without_password_ageing: ['pw_no_ageing']
+    os_auth_pw_warn_age: 7
     os_netrc_enabled: false
     os_ignore_users: ["shell_sys_acc"]
     os_ignore_home_folder_users: ["user_with_777_home"]

--- a/molecule/os_hardening/verify_tasks/pw_ageing.yml
+++ b/molecule/os_hardening/verify_tasks/pw_ageing.yml
@@ -14,9 +14,19 @@
   changed_when: false
   register: expiry_date
 
-- name: Check that the expiry date of pw_ageing is 30 days
+- name: Check that the expiry date of pw_ageing is 60 days
   ansible.builtin.assert:
     # this uses the date from the expire_date variable and subtracts the current date.
     # it should be bigger that the password_expire_min of the user "pw_no_ageing"
     that:
       - "{{ ( expiry_date.stdout | trim | to_datetime('%b %d, %Y') - ansible_date_time.date | to_datetime('%Y-%m-%d')).days }} == 60"
+
+- name: Get Password Expiry warning days for pw_ageing
+  ansible.builtin.shell: chage -l pw_ageing | grep "warning before password expires" | cut -d ":" -f 2
+  changed_when: false
+  register: expiry_warndays
+
+- name: Check that number of days of warning before password expires is 7 days
+  ansible.builtin.assert:
+    that:
+      - "expiry_warndays.stdout | trim == '7'"

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -107,6 +107,9 @@ We know that this is the case on Raspberry Pi.
 - `os_auth_pw_min_age`
   - Default: `7`
   - Description: minimum password age (before allowing any other password change).
+- `os_auth_pw_warn_age`
+  - Default: `7`
+  - Description: number of days of warning before password expires.
 - `os_auth_pw_remember`
   - Default: `5`
   - Description: how many used passwords are record.

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -3,6 +3,7 @@ os_desktop_enable: false
 os_env_extra_user_paths: []
 os_auth_pw_max_age: 60
 os_auth_pw_min_age: 7 # Discourage password cycling
+os_auth_pw_warn_age: 7
 os_auth_pw_remember: 5 # Specify how many used passwords are record
 os_auth_retries: 5
 os_auth_lockout_time: 600 # Seconds (600 = 10min)

--- a/roles/os_hardening/templates/etc/login.defs.j2
+++ b/roles/os_hardening/templates/etc/login.defs.j2
@@ -110,7 +110,7 @@ PASS_MAX_DAYS     {{ os_auth_pw_max_age }}
 PASS_MIN_DAYS     {{ os_auth_pw_min_age }}
 
 # Number of days warning given before a password expires.
-PASS_WARN_AGE     7
+PASS_WARN_AGE     {{ os_auth_pw_warn_age }}
 
 # Min/max values for automatic uid selection in useradd
 UID_MIN           {{ os_auth_uid_min }}


### PR DESCRIPTION
From my point of view, it would be helpful to be able to adjust the number of days on which warnings are given before the user password expires via a variable as well.

* adds a new variable `os_auth_pw_warn_age` (default `7`)

This solution currently affects newly created accounts only. Existing accounts remain unchanged - I'll make a proposal for this in a separate pull request. (Hopefully this [PR](https://github.com/ansible/ansible/pull/79884) will be accepted by Ansible maintainers.)