### PR TITLE
Only skip audit restart handler in docker

### DIFF
--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -5,7 +5,7 @@
 - name: Restart auditd # noqa command-instead-of-module
   ansible.builtin.command:
     cmd: service auditd restart # rhel: see: https://access.redhat.com/solutions/2664811
-  when: molecule_yml is not defined # restarting auditd in a container does not work
+  when: molecule_yml.driver.name | default() != "docker" # restarting auditd in a container does not work
 
 - name: Reload systemd
   ansible.builtin.systemd:


### PR DESCRIPTION
Thanks again for this collection!

We use this as a dependency in our own lightweight wrapper hardening collection. We test some auditd rules, so we spin up proper vagrant or ec2 machines, and would like to run some verify tasks on them. But we need to run the auditd handler in order to see that rules are applied correctly.

This narrows down the when condition to only skip if the `docker` driver is present. Would this make sense? I can extend this if needed, maybe I missed a few other use cases.

/cc @dlouzan @bufferoverflow 