### PR TITLE
Update test environment

### DIFF
--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -68,11 +68,6 @@ jobs:
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
-      - name: Create default collection path symlink
-        run: |
-          mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
-
       # that was a hard one to fix. robert did it thankfully
       # https://github.com/robertdebock/ansible-role-mysql/commit/7562e99099b06282391ab7ed102b393a0406d212
       - name: disable apparmor on debian systems

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -46,7 +46,7 @@ jobs:
           - debian10
           - debian11
           # - amazon  # geerlingguy.mysql does not support fedora
-          - arch
+          # - arch  # geerlingguy.mysql does not support arch
           - opensuse_tumbleweed
           # - fedora  # geerlingguy.mysql does not support fedora
     steps:

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -56,10 +56,10 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -46,8 +46,8 @@ jobs:
           - debian10
           - debian11
           # - amazon  # geerlingguy.mysql does not support fedora
-          # - arch  # needs to be fixed
-          - opensuse_tumbleweed  # needs to be fixed
+          - arch
+          - opensuse_tumbleweed
           # - fedora  # geerlingguy.mysql does not support fedora
     steps:
       - name: Checkout repo

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -45,8 +45,8 @@ jobs:
           - debian10
           - debian11
           - amazon2023
-          # - arch  # needs to be fixed
-          # - opensuse_tumbleweed  # needs to be fixed
+          - arch
+          - opensuse_tumbleweed
           # - fedora  # no support from geerlingguy role
     steps:
       - name: Checkout repo

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -67,11 +67,6 @@ jobs:
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
-      - name: Create default collection path symlink
-        run: |
-          mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
-
       - name: Test with molecule
         run: |
           molecule --version

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -44,7 +44,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon2
+          - amazon2023
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # needs to be fixed
           # - fedora  # no support from geerlingguy role

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -45,8 +45,8 @@ jobs:
           - debian10
           - debian11
           - amazon2023
-          - arch
-          - opensuse_tumbleweed
+          # - arch  # needs to be fixed
+          # - opensuse_tumbleweed  # needs to be fixed
           # - fedora  # no support from geerlingguy role
     steps:
       - name: Checkout repo

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -55,10 +55,10 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -44,7 +44,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon
+          - amazon2
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # needs to be fixed
           # - fedora  # no support from geerlingguy role

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -46,7 +46,7 @@ jobs:
           - debian11
           - amazon2023
           - opensuse_tumbleweed
-          # - arch  # needs to be fixed
+          - arch
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -44,7 +44,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon
+          - amazon2
           - opensuse_tumbleweed
           # - arch  # needs to be fixed
     steps:

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -44,7 +44,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon2
+          - amazon2023
           - opensuse_tumbleweed
           # - arch  # needs to be fixed
     steps:

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -39,6 +39,7 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
+          - fedora
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -54,10 +54,10 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -66,11 +66,6 @@ jobs:
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
-      - name: Create default collection path symlink
-        run: |
-          mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
-
       - name: Test with molecule
         run: |
           if [ "$MOLECULE_DISTRO" = "opensuse_tumbleweed" ]; then

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -39,6 +39,8 @@ jobs:
           - centos9s
           - rocky8
           - rocky9
+          - fedora36
+          - fedora37
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -45,7 +45,7 @@ jobs:
           - debian10
           - debian11
           - opensuse15
-          # - arch  # arch is currently not supported by cinc-auditor
+          - arch
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -45,7 +45,7 @@ jobs:
           - debian10
           - debian11
           - opensuse15
-          - arch
+          # - arch  # needs fix for audit
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon
+          - amazon2
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # baseline is not compatible with suse
     steps:

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -46,8 +46,8 @@ jobs:
           - debian10
           - debian11
           - amazon2023
-          # - arch  # needs to be fixed
-          # - opensuse_tumbleweed  # baseline is not compatible with suse
+          - arch
+          - opensuse_tumbleweed
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -47,7 +47,7 @@ jobs:
           - debian11
           - amazon2023
           - arch
-          - opensuse_tumbleweed
+          # - opensuse_tumbleweed  # needs fix - opensuse has different file location for conf and pam (/usr/etc/ssh/?, /usr/lib/pam.d/?)
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -55,10 +55,10 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon2
+          - amazon2023
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # baseline is not compatible with suse
     steps:

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -67,11 +67,6 @@ jobs:
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
-      - name: Create default collection path symlink
-        run: |
-          mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
-
       - name: Test with molecule
         run: |
           if [ "$MOLECULE_DISTRO" = "opensuse_tumbleweed" ]; then

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon
+          - amazon2
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # baseline is not compatible with suse
     steps:

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -46,8 +46,8 @@ jobs:
           - debian10
           - debian11
           - amazon2023
-          # - arch  # needs to be fixed
-          # - opensuse_tumbleweed  # baseline is not compatible with suse
+          - arch
+          - opensuse_tumbleweed
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -47,7 +47,7 @@ jobs:
           - debian11
           - amazon2023
           - arch
-          - opensuse_tumbleweed
+          # - opensuse_tumbleweed  # needs fix - opensuse has different file location for conf and pam (/usr/etc/ssh/?, /usr/lib/pam.d/?)
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1
@@ -55,10 +55,10 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
-          - amazon2
+          - amazon2023
           # - arch  # needs to be fixed
           # - opensuse_tumbleweed  # baseline is not compatible with suse
     steps:

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -67,11 +67,6 @@ jobs:
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
-      - name: Create default collection path symlink
-        run: |
-          mkdir -p /home/runner/.ansible
-          ln -s /home/runner/work/ansible-os-hardening/ansible-os-hardening /home/runner/.ansible/collections
-
       - name: Test with molecule
         run: |
           if [ "$MOLECULE_DISTRO" = "opensuse_tumbleweed" ]; then

--- a/molecule/mysql_hardening/molecule.yml
+++ b/molecule/mysql_hardening/molecule.yml
@@ -22,7 +22,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
 

--- a/molecule/mysql_hardening/requirements.yml
+++ b/molecule/mysql_hardening/requirements.yml
@@ -1,7 +1,5 @@
 ---
 roles:
-  - name: geerlingguy.git
-    version: 3.0.1
   - name: dev-sec.mysql
     version: master
 

--- a/molecule/mysql_hardening/verify.yml
+++ b/molecule/mysql_hardening/verify.yml
@@ -13,6 +13,13 @@
       when:
         - ansible_os_family == 'Suse'
 
+    - name: install procps for debian systems
+      apt:
+        name: procps
+        state: present
+        update_cache: true
+      when: ansible_distribution == 'Debian'
+
     - name: include tests for the service
       include_tasks: verify_tasks/service.yml
 

--- a/molecule/mysql_hardening/verify.yml
+++ b/molecule/mysql_hardening/verify.yml
@@ -6,34 +6,7 @@
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  roles:
-    - geerlingguy.git
   tasks:
-    - name: install fake SuSE-release for cinc compatibility
-      copy:
-        content: |
-          openSUSE Faked Enterprise 2020 (x86_64)
-          VERSION = 2020
-          CODENAME = Faked Feature
-        dest: /etc/SuSE-release
-        owner: root
-        group: root
-        mode: '0444'
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install git for SuSE since geerlinguy.git does not support it
-      zypper:
-        name: git
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install procps for debian systems
-      apt:
-        name: procps
-        state: present
-        update_cache: true
-      when: ansible_distribution == 'Debian'
-
     - name: Use Python 3 on Suse
       set_fact:
         ansible_python_interpreter: /usr/bin/python3
@@ -46,17 +19,21 @@
     - name: include tests for MySQL user
       include_tasks: verify_tasks/mysql_users.yml
 
-    - name: download cinc-auditor
-      get_url:
-        url: https://omnitruck.cinc.sh/install.sh
-        dest: /tmp/install.sh
-        mode: '0775'
-
-    - name: install cinc-auditor
-      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
-
+- name: Verify
+  hosts: localhost
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  tasks:
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/mysql-baseline/archive/refs/heads/master.zip"
+      command: >
+        docker run
+        --volume /run/docker.sock:/run/docker.sock
+        docker.io/cincproject/auditor exec
+        -t docker://instance
+        --no-show-progress --no-color
+        --no-distinct-exit https://github.com/dev-sec/mysql-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/nginx_hardening/converge.yml
+++ b/molecule/nginx_hardening/converge.yml
@@ -2,6 +2,8 @@
 - name: wrapper playbook for kitchen testing "ansible-nginx-hardening" with custom settings
   become: true
   hosts: all
+  collections:
+    - devsec.hardening
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"

--- a/molecule/nginx_hardening/molecule.yml
+++ b/molecule/nginx_hardening/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
 

--- a/molecule/nginx_hardening/prepare.yml
+++ b/molecule/nginx_hardening/prepare.yml
@@ -2,6 +2,8 @@
 - name: prepare playbook for kitchen testing "ansible-nginx-hardening" with custom settings
   become: true
   hosts: all
+  collections:
+    - devsec.hardening
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"

--- a/molecule/nginx_hardening/prepare.yml
+++ b/molecule/nginx_hardening/prepare.yml
@@ -2,8 +2,6 @@
 - name: prepare playbook for kitchen testing "ansible-nginx-hardening" with custom settings
   become: true
   hosts: all
-  collections:
-    - devsec.hardening
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"

--- a/molecule/nginx_hardening/requirements.yml
+++ b/molecule/nginx_hardening/requirements.yml
@@ -1,4 +1,3 @@
 ---
 roles:
-  - geerlingguy.git
   - geerlingguy.nginx

--- a/molecule/nginx_hardening/verify.yml
+++ b/molecule/nginx_hardening/verify.yml
@@ -1,53 +1,18 @@
----
 - name: Verify
-  hosts: all
-  become: true
+  hosts: localhost
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  roles:
-    - geerlingguy.git
   tasks:
-    - name: install fake SuSE-release for cinc compatibility
-      copy:
-        content: |
-          openSUSE Faked Enterprise 2020 (x86_64)
-          VERSION = 2020
-          CODENAME = Faked Feature
-        dest: /etc/SuSE-release
-        owner: root
-        group: root
-        mode: '0444'
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install git for SuSE since geerlinguy.git does not support it
-      zypper:
-        name: git
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: Run the equivalent of "apt-get update" as a separate step
-      apt:
-        update_cache: true
-      when: ansible_facts.os_family == 'Debian'
-
-    - name: install required tools on debian
-      apt:
-        name: procps
-      when: ansible_facts.os_family == 'Debian'
-
-    - name: download cinc-auditor
-      get_url:
-        url: https://omnitruck.cinc.sh/install.sh
-        dest: /tmp/install.sh
-        mode: '0775'
-
-    - name: install cinc-auditor
-      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
-
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/nginx-baseline/archive/refs/heads/master.zip"
+      command: >
+        docker run
+        --volume /run/docker.sock:/run/docker.sock
+        docker.io/cincproject/auditor exec
+        -t docker://instance
+        --no-show-progress --no-color
+        --no-distinct-exit https://github.com/dev-sec/nginx-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/nginx_hardening/verify.yml
+++ b/molecule/nginx_hardening/verify.yml
@@ -1,3 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  tasks:
+    - name: install procps for debian systems
+      apt:
+        name: procps
+        state: present
+        update_cache: true
+      when: ansible_distribution == 'Debian'
+
 - name: Verify
   hosts: localhost
   environment:

--- a/molecule/os_hardening/molecule.yml
+++ b/molecule/os_hardening/molecule.yml
@@ -1,8 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    role-file: molecule/os_hardening/requirements.yml
 driver:
   name: docker
 platforms:

--- a/molecule/os_hardening/molecule.yml
+++ b/molecule/os_hardening/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
 

--- a/molecule/os_hardening/prepare.yml
+++ b/molecule/os_hardening/prepare.yml
@@ -2,8 +2,6 @@
 - name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
   hosts: all
   become: true
-  collections:
-    - devsec.hardening
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"

--- a/molecule/os_hardening/requirements.yml
+++ b/molecule/os_hardening/requirements.yml
@@ -1,3 +1,0 @@
----
-roles:
-  - geerlingguy.git

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -6,39 +6,9 @@
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  roles:
-    - geerlingguy.git
   collections:
     - devsec.hardening
   tasks:
-    - name: install fake SuSE-release for cinc compatibility
-      copy:
-        content: |
-          openSUSE Faked Enterprise 2020 (x86_64)
-          VERSION = 2020
-          CODENAME = Faked Feature
-        dest: /etc/SuSE-release
-        owner: root
-        group: root
-        mode: '0444'
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install git for SuSE since geerlinguy.git does not support it
-      zypper:
-        name: git
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: Run the equivalent of "apt-get update" as a separate step
-      apt:
-        update_cache: true
-      when: ansible_facts.os_family == 'Debian'
-
-    - name: install required tools on debian
-      apt:
-        name: procps
-      when: ansible_facts.os_family == 'Debian'
-
     - name: include verification tasks
       ansible.builtin.include_tasks:
         file: "{{ item }}"
@@ -56,17 +26,22 @@
       include_tasks: verify_tasks/yum.yml
       when: ansible_facts.os_family == 'RedHat'
 
-    - name: download cinc-auditor
-      get_url:
-        url: https://omnitruck.cinc.sh/install.sh
-        dest: /tmp/install.sh
-        mode: '0775'
-
-    - name: install cinc-auditor
-      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
-
-    - name: Execute cinc-auditor tests  # noqa ignore-errors
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit --waiver-file waivers.yaml https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
+- name: Verify
+  hosts: localhost
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  tasks:
+    - name: Execute cinc-auditor tests
+      command: >
+        docker run
+        --volume /run/docker.sock:/run/docker.sock
+        --volume ./waivers.yaml:/waivers.yaml
+        docker.io/cincproject/auditor exec
+        -t docker://instance
+        --no-show-progress --no-color
+        --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -6,8 +6,6 @@
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  collections:
-    - devsec.hardening
   tasks:
     - name: include verification tasks
       ansible.builtin.include_tasks:

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -37,10 +37,11 @@
       command: >
         docker run
         --volume /run/docker.sock:/run/docker.sock
-        --volume /home/runner/work/ansible-collection-hardening/ansible-collection-hardening/ansible_collections/devsec/hardening/molecule/os_hardening/waivers.yaml:/waivers.yaml
+        --volume {{ playbook_dir }}/waivers.yaml:/waivers.yaml
         docker.io/cincproject/auditor exec
         -t docker://instance
         --no-show-progress --no-color
+        --waiver-file /waivers.yaml
         --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -8,6 +8,8 @@
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
   roles:
     - geerlingguy.git
+  collections:
+    - devsec.hardening
   tasks:
     - name: install fake SuSE-release for cinc compatibility
       copy:

--- a/molecule/os_hardening/verify.yml
+++ b/molecule/os_hardening/verify.yml
@@ -37,7 +37,7 @@
       command: >
         docker run
         --volume /run/docker.sock:/run/docker.sock
-        --volume ./waivers.yaml:/waivers.yaml
+        --volume /home/runner/work/ansible-collection-hardening/ansible-collection-hardening/ansible_collections/devsec/hardening/molecule/os_hardening/waivers.yaml:/waivers.yaml
         docker.io/cincproject/auditor exec
         -t docker://instance
         --no-show-progress --no-color
@@ -55,6 +55,16 @@
         msg: "Inspec failed to validate"
       when: test_results.rc != 0
 
+- name: Verify
+  hosts: all
+  become: true
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  collections:
+    - devsec.hardening
+  tasks:
     # test if variable can be overridden
     - name: workaround for https://github.com/ansible/ansible/issues/66304
       set_fact:

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -24,7 +24,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
   env:

--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -2,8 +2,6 @@
 - name: wrapper playbook for kitchen testing "ansible-os-hardening" with custom vars for testing
   hosts: all
   become: true
-  collections:
-    - devsec.hardening
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"

--- a/molecule/os_hardening_vm/verify.yml
+++ b/molecule/os_hardening_vm/verify.yml
@@ -6,36 +6,7 @@
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  roles:
-    - geerlingguy.git
   tasks:
-    - name: install fake SuSE-release for cinc compatibility
-      copy:
-        content: |
-          openSUSE Faked Enterprise 2020 (x86_64)
-          VERSION = 2020
-          CODENAME = Faked Feature
-        dest: /etc/SuSE-release
-        owner: root
-        group: root
-        mode: '0444'
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install git for SuSE since geerlinguy.git does not support it
-      zypper:
-        name: git
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: Run the equivalent of "apt-get update" as a separate step
-      apt:
-        update_cache: true
-      when: ansible_facts.os_family == 'Debian'
-
-    - name: install required tools on debian
-      apt:
-        name: procps
-      when: ansible_facts.os_family == 'Debian'
 
     - name: include PAM tests
       include_tasks: verify_tasks/pam.yml
@@ -45,17 +16,35 @@
       include_tasks: verify_tasks/yum.yml
       when: ansible_facts.os_family == 'RedHat'
 
-    - name: download cinc-auditor
-      get_url:
-        url: https://omnitruck.cinc.sh/install.sh
-        dest: /tmp/install.sh
-        mode: '0775'
+- name: Verify
+  hosts: localhost
+  environment:
+    http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
+    https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
+  tasks:
+    - name: get ssh-config
+      command:
+        cmd: "vagrant ssh-config"
+        chdir: "{{ molecule_ephemeral_directory }}"
+      register: ssh_config
+      changed_when: false
 
-    - name: install cinc-auditor
-      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
+    - name: create ssh-config file
+      copy:
+        content: "{{ ssh_config.stdout_lines | join ('\n') }}"
+        dest: "{{ molecule_ephemeral_directory }}/ssh-config"
+      changed_when: false
 
-    - name: Execute cinc-auditor tests  # noqa ignore-errors
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip"
+    - name: Execute cinc-auditor tests
+      command: >
+        docker run
+        --volume {{ molecule_ephemeral_directory }}:{{ molecule_ephemeral_directory }}
+        docker.io/cincproject/auditor exec
+        --ssh-config-file={{ molecule_ephemeral_directory }}/ssh-config
+        -t ssh://{{ lookup('env', 'USER') }}
+        --sudo --no-show-progress --no-color
+        --no-distinct-exit https://github.com/dev-sec/linux-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/ssh_hardening/molecule.yml
+++ b/molecule/ssh_hardening/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
   inventory:
     host_vars:
       # https://molecule.readthedocs.io/en/latest/examples.html#docker-with-non-privileged-user

--- a/molecule/ssh_hardening/molecule.yml
+++ b/molecule/ssh_hardening/molecule.yml
@@ -1,8 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    role-file: molecule/ssh_hardening/requirements.yml
 driver:
   name: docker
 platforms:

--- a/molecule/ssh_hardening/requirements.yml
+++ b/molecule/ssh_hardening/requirements.yml
@@ -1,3 +1,0 @@
----
-roles:
-  - geerlingguy.git

--- a/molecule/ssh_hardening/verify.yml
+++ b/molecule/ssh_hardening/verify.yml
@@ -32,17 +32,14 @@
         name: libxcrypt-compat
       when: ansible_facts.distribution == 'Fedora'
 
-    - name: download cinc-auditor
-      get_url:
-        url: https://omnitruck.cinc.sh/install.sh
-        dest: /tmp/install.sh
-        mode: '0775'
-
-    - name: install cinc-auditor
-      shell: "bash /tmp/install.sh -s -- -P cinc-auditor -v 4"
-
     - name: Execute cinc-auditor tests
-      command: "/opt/cinc-auditor/bin/cinc-auditor exec --no-show-progress --no-color --no-distinct-exit https://github.com/dev-sec/ssh-baseline/archive/refs/heads/master.zip"
+      command: >
+        docker run
+        --volume /run/docker.sock:/run/docker.sock
+        docker.io/cincproject/auditor exec
+        -t docker://instance
+        --sudo --no-show-progress --no-color
+        --no-distinct-exit https://github.com/dev-sec/ssh-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false
       ignore_errors: true

--- a/molecule/ssh_hardening/verify.yml
+++ b/molecule/ssh_hardening/verify.yml
@@ -1,44 +1,18 @@
 ---
 - name: Verify
-  hosts: all
-  become: true
+  hosts: localhost
   environment:
     http_proxy: "{{ lookup('env', 'http_proxy') | default(omit)  }}"
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
-  roles:
-    - geerlingguy.git
   tasks:
-    - name: install fake SuSE-release for cinc compatibility
-      copy:
-        content: |
-          openSUSE Faked Enterprise 2020 (x86_64)
-          VERSION = 2020
-          CODENAME = Faked Feature
-        dest: /etc/SuSE-release
-        owner: root
-        group: root
-        mode: '0444'
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install git for SuSE since geerlinguy.git does not support it
-      zypper:
-        name: git
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
-    - name: install crypto compat modules on fedora
-      dnf:
-        name: libxcrypt-compat
-      when: ansible_facts.distribution == 'Fedora'
-
     - name: Execute cinc-auditor tests
       command: >
         docker run
         --volume /run/docker.sock:/run/docker.sock
         docker.io/cincproject/auditor exec
         -t docker://instance
-        --sudo --no-show-progress --no-color
+        --no-show-progress --no-color
         --no-distinct-exit https://github.com/dev-sec/ssh-baseline/archive/refs/heads/master.zip
       register: test_results
       changed_when: false

--- a/molecule/ssh_hardening_bsd/molecule.yml
+++ b/molecule/ssh_hardening_bsd/molecule.yml
@@ -1,8 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    role-file: molecule/ssh_hardening_bsd/requirements.yml
 driver:
   name: vagrant
   provider:

--- a/molecule/ssh_hardening_bsd/molecule.yml
+++ b/molecule/ssh_hardening_bsd/molecule.yml
@@ -24,7 +24,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
   env:

--- a/molecule/ssh_hardening_bsd/requirements.yml
+++ b/molecule/ssh_hardening_bsd/requirements.yml
@@ -1,3 +1,0 @@
----
-roles:
-  - geerlingguy.git

--- a/molecule/ssh_hardening_custom_tests/molecule.yml
+++ b/molecule/ssh_hardening_custom_tests/molecule.yml
@@ -1,8 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    role-file: molecule/ssh_hardening/requirements.yml
 driver:
   name: docker
 platforms:

--- a/molecule/ssh_hardening_custom_tests/molecule.yml
+++ b/molecule/ssh_hardening_custom_tests/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callback_whitelist: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer, yaml
 verifier:
   name: ansible
 

--- a/molecule/ssh_hardening_custom_tests/requirements.yml
+++ b/molecule/ssh_hardening_custom_tests/requirements.yml
@@ -1,3 +1,0 @@
----
-roles:
-  - geerlingguy.git

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
       versions:
         - "7"
         - "8"
+        - "9"
     - name: Ubuntu
       versions:
         - bionic
@@ -20,7 +21,7 @@ galaxy_info:
         - bullseye
         - buster
     - name: Amazon
-    - name: Fedora
+    - name: opensuse
   galaxy_tags:
     - system
     - security

--- a/roles/nginx_hardening/meta/main.yml
+++ b/roles/nginx_hardening/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
       versions:
         - "7"
         - "8"
+        - "9"
     - name: Ubuntu
       versions:
         - bionic
@@ -19,6 +20,7 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+    - name: Amazon
   galaxy_tags:
     - system
     - security

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
       versions:
         - "7"
         - "8"
+        - "9"
     - name: Ubuntu
       versions:
         - bionic

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
       versions:
         - "7"
         - "8"
+        - "9"
     - name: Ubuntu
       versions:
         - bionic
@@ -23,7 +24,6 @@ galaxy_info:
     - name: Fedora
     - name: ArchLinux
     - name: SmartOS
-    - name: opensuse
     - name: FreeBSD
       versions:
         - "12.2"


### PR DESCRIPTION
Our testing environment was a bit dated. Now we use the current ubuntu images from GitHub and a more recent version of Python. This also let's us use current versions of Molecule, etc.

Also some steps (sym-linking the collection to a fix location) are now unneccessary and are removed. 

We switched from installing inspec in each system under test to using a premade Docker container. Tihs is much faster and supports all operating systems. This helps us include Arch Linux and SuSE. It also greatly simplifies out verify Playbooks.

Finally we solved some deprecation warnings. :D

I did some analyses on the still failing tests for Arch and SuSE, but will open separate Issues for fixing them.