### PR TITLE
Update minimum required Ansible version for os_hardening

### DIFF
--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Update-initramfs
+- name: Update-initramfs # noqa no-changed-when
   ansible.builtin.command: update-initramfs -u
 
-- name: Restart auditd # noqa command-instead-of-module
+- name: Restart auditd # noqa command-instead-of-module no-changed-when
   ansible.builtin.command:
     cmd: service auditd restart # rhel: see: https://access.redhat.com/solutions/2664811
   when: molecule_yml.driver.name | default() != "docker" # restarting auditd in a container does not work

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: This Ansible role provides numerous security-related ssh configurations, providing all-round base protection.
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: 2.11
+  min_ansible_version: "2.11"
   platforms:
     - name: EL
       versions:

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: This Ansible role provides numerous security-related ssh configurations, providing all-round base protection.
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: 2.9.10
+  min_ansible_version: 2.11
   platforms:
     - name: EL
       versions:

--- a/roles/os_hardening/tasks/limits.yml
+++ b/roles/os_hardening/tasks/limits.yml
@@ -35,7 +35,7 @@
         path: /etc/systemd/coredump.conf.d
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
         state: directory
       when: ansible_service_mgr == "systemd"
 
@@ -45,7 +45,7 @@
         dest: /etc/systemd/coredump.conf.d/custom.conf
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
       when: ansible_service_mgr == "systemd"
       notify: Reload systemd
 

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -53,7 +53,7 @@
 
 - name: Set ownership of root user home directory(s) to 0700
   ansible.builtin.file:
-    mode: 0700
+    mode: "0700"
     owner: "{{ item }}"
     path: "{{ getent_passwd[item][4] }}"
     state: directory
@@ -100,7 +100,7 @@
 
 - name: Limit access to home directories of regular (non-system, non-root) accounts
   ansible.builtin.file:
-    mode: 0700
+    mode: "0700"
     owner: "{{ item }}"
     path: "{{ getent_passwd[item][4] }}"
     state: directory

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -100,7 +100,7 @@
   check_mode: false
   when: ssh_server_hardening | bool
 
-- name: Remove all small primes
+- name: Remove all small primes # noqa no-changed-when
   ansible.builtin.shell: >
     awk '$5 >= {{ sshd_moduli_minimum }}' {{ sshd_moduli_file }} > {{ sshd_moduli_file }}.new ; [ -r {{ sshd_moduli_file }}.new
     -a -s {{ sshd_moduli_file }}.new ] && mv {{ sshd_moduli_file }}.new {{ sshd_moduli_file }} || true

--- a/roles/ssh_hardening/tasks/selinux.yml
+++ b/roles/ssh_hardening/tasks/selinux.yml
@@ -57,7 +57,7 @@
 # The following tasks only get executed when selinux is installed, UsePam is
 # 'yes' and the ssh_password module is installed. See
 # http://danwalsh.livejournal.com/12333.html for more info
-- name: Remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk
+- name: Remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk # noqa no-changed-when
   ansible.builtin.command: semodule -r ssh_password
   when:
     - ssh_use_pam | bool

--- a/roles/ssh_hardening/tasks/selinux.yml
+++ b/roles/ssh_hardening/tasks/selinux.yml
@@ -57,7 +57,7 @@
 # The following tasks only get executed when selinux is installed, UsePam is
 # 'yes' and the ssh_password module is installed. See
 # http://danwalsh.livejournal.com/12333.html for more info
-- name: Remove selinux-policy when Pam is used, because Allowing sshd to read the shadow file directly is considered a potential security risk # noqa no-changed-when
+- name: Remove selinux-policy when PAM is used, because allowing sshd to read the shadow file is considered a security risk # noqa no-changed-when
   ansible.builtin.command: semodule -r ssh_password
   when:
     - ssh_use_pam | bool


### PR DESCRIPTION
We use options from `ansible.builtin.user` that are first introduced in 2.11. (`password_expire_max`, `password_expire_min`)

see: https://github.com/ansible/ansible/blob/f9534fd7b7e8c7f3314d68f62025ebc9499a72f5/lib/ansible/modules/user.py#L245-L256