### PR TITLE
changes made to make os_hardening compatible with immutable filesystem (atomic-container)

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -561,7 +561,7 @@ If you are using os_hardening with a filesystem that has immutable directories i
   - Description: Add list of user to allow creation of .netrc in users homedir
 - `os_immutable_fs`
   - Default: `ansible_facts.pkg_mgr == 'atomic_container'`
-  - Description: Specify that file system is immutable in accordance with ostree system ie coreos/silverblue 
+  - Description: Specify file system as immutable in accordance with ostree system ie coreos/silverblue 
 
 ## Packages
 

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -90,6 +90,10 @@ Otherwise inspec will fail. For more information, see [issue #124](https://githu
 
 We know that this is the case on Raspberry Pi.
 
+### Using with ostree system, ie coreos/silverblue
+
+If you are using os_hardening with a filesystem that has immutable directories in accordance with the ostree specification, then you can set the variable `os_immutable_fs: true`.  It defaults to `ansible_facts.pkg_mgr == 'atomic_container'` and so should compensate for the immutable file system by default.
+
 ## Variables
 
 - `os_desktop_enable`
@@ -555,6 +559,9 @@ We know that this is the case on Raspberry Pi.
 - `os_netrc_whitelist_user`
   - Default: ``
   - Description: Add list of user to allow creation of .netrc in users homedir
+- `os_immutable_fs`
+  - Default: `ansible_facts.pkg_mgr == 'atomic_container'`
+  - Description: Specify that file system is immutable in accordance with ostree system ie coreos/silverblue 
 
 ## Packages
 

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -54,6 +54,9 @@ os_security_packages_list: [xinetd, inetd, ypserv, telnet-server, rsh-server, pr
 os_security_init_prompt: true
 # Require root password for single user mode. (rhel, centos)
 os_security_init_single: false
+# Set to true if filesystem is immutable (ie ostree or similar)
+os_immutable_fs: ansible_facts.pkg_mgr == 'atomic_container'
+
 
 # Apply ufw defaults
 ufw_manage_defaults: true

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -71,7 +71,9 @@
     owner: root
     group: root
     mode: "0750"
-  when: '"change_user" not in os_security_users_allow'
+  when:
+    - '"change_user" not in os_security_users_allow'
+    - not os_immutable_fs
 
 - name: Set option hidepid for proc filesystem
   ansible.posix.mount:
@@ -98,7 +100,7 @@
       src: "{{ os_mnt_boot_src }}"
       fstype: "{{ os_mnt_boot_filesystem }}"
       opts: "{{ os_mnt_boot_options }}"
-      enabled: "{{ os_mnt_boot_enabled }}"
+      enabled: "{{ os_mnt_boot_enabled and not os_immutable_fs }}"
       mode: "{{ os_mnt_boot_dir_mode }}"
       group: "{{ os_mnt_boot_group }}"
       owner: "{{ os_mnt_boot_owner }}"

--- a/roles/os_hardening/tasks/minimize_access_fs.yml
+++ b/roles/os_hardening/tasks/minimize_access_fs.yml
@@ -28,7 +28,7 @@
     group: "{{ mount.group }}"
     mode: "{{ mount.mode }}"
   when:
-    - mountpoint_exists.stat.exists | bool
+    - mountpoint_exists.stat.exists and mountpoint_exists.stat.writeable | bool
 
 - name: "Register changed mountpoints"
   ansible.builtin.set_fact:

--- a/roles/os_hardening/tasks/modprobe.yml
+++ b/roles/os_hardening/tasks/modprobe.yml
@@ -3,6 +3,7 @@
   ansible.builtin.package:
     name: "{{ modprobe_package }}"
     state: present
+  when: ansible_facts.pkg_mgr != 'atomic_container'
 
 - name: Check if efi is installed
   ansible.builtin.stat:

--- a/roles/os_hardening/tasks/pam.yml
+++ b/roles/os_hardening/tasks/pam.yml
@@ -16,6 +16,7 @@
     state: absent
   when:
     - ansible_facts.os_family != 'Archlinux'
+    - ansible_facts.pkg_mgr != 'atomic_container'
 
 - name: Import tasks for Debian PAM
   ansible.builtin.import_tasks: pam_debian.yml

--- a/roles/os_hardening/tasks/pam_rhel.yml
+++ b/roles/os_hardening/tasks/pam_rhel.yml
@@ -5,6 +5,7 @@
     state: present
   when:
     - os_auth_pam_sssd_enable | bool
+    - ansible_facts.pkg_mgr != 'atomic_container'
 
 - name: Configure passwdqc and faillock via central system-auth config
   ansible.builtin.template:


### PR DESCRIPTION
Introduced new default var `os_immutable_fs` which defaults to `ansible_facts.pkg_mgr not 'atomic_container'`.  

Prevented ansible.builtin.packages and yum etc from installing or removing files on atomic_container systems, due to requirement to reboot and to use community.general.rpm_ostree instead of ansible.builtin.packages

os_hardening now runs without fail on my core_os system.  I set 
```
os_auditd_enabled: false   # auditd is already installed
os_immutable_fs: true # new var to indicate immutable filesystem.  Defaults/main.yml to 'not atomic_container'
```