### PR TITLE
use new molecule-plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-molecule[docker]
+molecule
+molecule-plugins[docker]
 yamllint
 ansible
 ansible-lint


### PR DESCRIPTION
Molecule has reorganized their plugins and now we need to use different python modules.

see: https://github.com/ansible-community/molecule/pull/3899