### PR TITLE
expand on check conditions for non-file locations of logs

### DIFF
--- a/roles/mysql_hardening/tasks/configure.yml
+++ b/roles/mysql_hardening/tasks/configure.yml
@@ -27,7 +27,11 @@
     owner: "{{ mysql_hardening_user }}"
     group: "{{ mysql_hardening_group }}"
     mode: "0640"
-  when: item is defined and item != ""
+  when:
+    - item is defined
+    - item != ""
+    - item != "stderr"
+    - item != "stdout"
   loop:
     - "{{ mysql_settings.settings.log_error }}"
     - '{{ mysql_hardening_log_file | default("") }}'


### PR DESCRIPTION
this fixes #673 

additional conditions will check for error_log setting being stderr or stdout, as these are valid non-file destinations for logs