### PR TITLE
Add oddjob mkhomedir option rhel pam

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -9,6 +9,7 @@ os_auth_retries: 5
 os_auth_lockout_time: 600 # Seconds (600 = 10min)
 os_auth_timeout: 60
 os_auth_allow_homeless: false
+os_auth_pam_oddjob_mkhomedir: false
 os_auth_pam_passwdqc_enable: true
 os_auth_pam_passwdqc_options: min=disabled,disabled,16,12,8 # Used in Debian
 os_auth_pam_pwquality_options: try_first_pass retry=3 authtok_type= # Used in RHEL7 and RHEL8

--- a/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
+++ b/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
@@ -47,6 +47,9 @@ password    required      pam_deny.so
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
 -session    optional      pam_systemd.so
+{% if (os_auth_pam_oddjob_mkhomedir ) %}
+session     optional      pam_oddjob_mkhomedir.so umask=0077
+{% endif %}
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     required      pam_unix.so
 {% if (os_auth_pam_sssd_enable | bool) %}

--- a/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
+++ b/roles/os_hardening/templates/etc/pam.d/rhel_auth.j2
@@ -47,7 +47,7 @@ password    required      pam_deny.so
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
 -session    optional      pam_systemd.so
-{% if (os_auth_pam_oddjob_mkhomedir ) %}
+{% if (os_auth_pam_oddjob_mkhomedir | bool) %}
 session     optional      pam_oddjob_mkhomedir.so umask=0077
 {% endif %}
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid


### PR DESCRIPTION
Added mkhomedir option for RedHat based systems, e.g. in FreeIPA environments.