### PR TITLE
Replace ssh_keys group in Fedora with root

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -12,3 +12,6 @@ exclude_paths:
 mock_roles:
   - geerlingguy.git
   - nginxinc.nginx
+
+skip_list:
+  - var-naming[no-role-prefix]

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -8,16 +8,6 @@
     force: false
     regenerate: partial_idempotence
 
-# In RHEL and Fedora, the 'ssh_keys' group is the group owner of the host private SSH keys.
-# Since the openssh_keypair module needs to read the key to provide idempotency, we need to set ownership and group based on specific OS vars.
-- name: Change host private key ownership, group and permissions
-  ansible.builtin.file:
-    path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
-    owner: "{{ ssh_host_keys_owner }}"
-    group: "{{ ssh_host_keys_group }}"
-    mode: "{{ ssh_host_keys_mode }}"
-  when: ansible_facts.os_family == 'RedHat'
-
 - name: Set hostkeys according to openssh-version if openssh >= 5.3
   ansible.builtin.set_fact:
     ssh_host_key_files:
@@ -38,3 +28,11 @@
       - "{{ ssh_host_keys_dir }}/ssh_host_ecdsa_key"
       - "{{ ssh_host_keys_dir }}/ssh_host_ed25519_key"
   when: sshd_version is version('6.3', '>=')
+
+- name: Change host private key ownership, group and permissions
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ ssh_host_keys_owner }}"
+    group: "{{ ssh_host_keys_group }}"
+    mode: "{{ ssh_host_keys_mode }}"
+  loop: "{{ ssh_host_key_files }}"

--- a/roles/ssh_hardening/tasks/crypto_hostkeys.yml
+++ b/roles/ssh_hardening/tasks/crypto_hostkeys.yml
@@ -15,7 +15,7 @@
     path: "{{ ssh_host_keys_dir }}/ssh_host_rsa_key"
     owner: "{{ ssh_host_keys_owner }}"
     group: "{{ ssh_host_keys_group }}"
-    mode: "0640"
+    mode: "{{ ssh_host_keys_mode }}"
   when: ansible_facts.os_family == 'RedHat'
 
 - name: Set hostkeys according to openssh-version if openssh >= 5.3

--- a/roles/ssh_hardening/vars/Amazon_2.yml
+++ b/roles/ssh_hardening/vars/Amazon_2.yml
@@ -1,11 +1,12 @@
 ---
 sshd_path: /usr/sbin/sshd
-ssh_host_keys_dir: '/etc/ssh'
+ssh_host_keys_dir: /etc/ssh
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
-ssh_host_keys_owner: 'root'
-ssh_host_keys_group: 'ssh_keys'
+ssh_host_keys_owner: root
+ssh_host_keys_group: ssh_keys
+ssh_host_keys_mode: "0640"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy
@@ -16,7 +17,7 @@ ssh_kerberos_support: true
 # true if SSH has PAM support
 ssh_pam_support: true
 
-sshd_moduli_file: '/etc/ssh/moduli'
+sshd_moduli_file: /etc/ssh/moduli
 
 # disable CRYPTO_POLICY to take settings from sshd configuration
 # see: https://access.redhat.com/solutions/4410591

--- a/roles/ssh_hardening/vars/Amazon_2.yml
+++ b/roles/ssh_hardening/vars/Amazon_2.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Archlinux.yml
+++ b/roles/ssh_hardening/vars/Archlinux.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0640"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Archlinux.yml
+++ b/roles/ssh_hardening/vars/Archlinux.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Debian.yml
+++ b/roles/ssh_hardening/vars/Debian.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0640"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Debian.yml
+++ b/roles/ssh_hardening/vars/Debian.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Fedora.yml
+++ b/roles/ssh_hardening/vars/Fedora.yml
@@ -5,7 +5,7 @@ sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
-ssh_host_keys_group: ssh_keys
+ssh_host_keys_group: root
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/Fedora.yml
+++ b/roles/ssh_hardening/vars/Fedora.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/FreeBSD.yml
+++ b/roles/ssh_hardening/vars/FreeBSD.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0640"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/FreeBSD.yml
+++ b/roles/ssh_hardening/vars/FreeBSD.yml
@@ -5,7 +5,7 @@ sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
-ssh_host_keys_group: root
+ssh_host_keys_group: wheel
 ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos

--- a/roles/ssh_hardening/vars/FreeBSD.yml
+++ b/roles/ssh_hardening/vars/FreeBSD.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/OpenBSD.yml
+++ b/roles/ssh_hardening/vars/OpenBSD.yml
@@ -5,7 +5,7 @@ sshd_service_name: sshd
 ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
-ssh_host_keys_group: root
+ssh_host_keys_group: wheel
 ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos

--- a/roles/ssh_hardening/vars/OpenBSD.yml
+++ b/roles/ssh_hardening/vars/OpenBSD.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0640"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: false

--- a/roles/ssh_hardening/vars/OpenBSD.yml
+++ b/roles/ssh_hardening/vars/OpenBSD.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: false

--- a/roles/ssh_hardening/vars/RedHat.yml
+++ b/roles/ssh_hardening/vars/RedHat.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
+ssh_host_keys_mode: "0640"
 ssh_selinux_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat.yml
+++ b/roles/ssh_hardening/vars/RedHat.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_7.yml
+++ b/roles/ssh_hardening/vars/RedHat_7.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_7.yml
+++ b/roles/ssh_hardening/vars/RedHat_7.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
+ssh_host_keys_mode: "0640"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_9.yml
+++ b/roles/ssh_hardening/vars/RedHat_9.yml
@@ -6,7 +6,10 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
+ssh_selinux_packages:
+  - policycoreutils-python-utils
+  - checkpolicy
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true
@@ -16,4 +19,6 @@ ssh_pam_support: true
 
 sshd_moduli_file: /etc/ssh/moduli
 
-sshd_disable_crypto_policy: false
+# disable CRYPTO_POLICY to take settings from sshd configuration
+# see: https://access.redhat.com/solutions/4410591
+sshd_disable_crypto_policy: true

--- a/roles/ssh_hardening/vars/SmartOS.yml
+++ b/roles/ssh_hardening/vars/SmartOS.yml
@@ -6,6 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
+ssh_host_keys_mode: "0640"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/SmartOS.yml
+++ b/roles/ssh_hardening/vars/SmartOS.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Suse.yml
+++ b/roles/ssh_hardening/vars/Suse.yml
@@ -6,7 +6,7 @@ ssh_owner: root
 ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
-ssh_host_keys_mode: "0640"
+ssh_host_keys_mode: "0600"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true


### PR DESCRIPTION
In Fedora 38, the `ssh_keys` group was removed. root is used now, in accordance to upstream.

See: https://www.spinics.net/lists/fedora-devel/msg307707.html
See: https://src.fedoraproject.org/rpms/openssh/pull-request/37#