### PR TITLE
add var-naming[no-role-prefix] to skip-list

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -12,3 +12,6 @@ exclude_paths:
 mock_roles:
   - geerlingguy.git
   - nginxinc.nginx
+
+skip_list:
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
there's probably some added value for this, but I see no reason to change so many variables and possibly break something when it still works and nobody complained