### PR TITLE
feat: explicitly support Fedora 37 and 38

### DIFF
--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -39,7 +39,8 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
-          - fedora
+          - fedora37
+          - fedora38
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -39,8 +39,8 @@ jobs:
           - centos9s
           - rocky8
           - rocky9
-          - fedora36
           - fedora37
+          - fedora38
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -39,7 +39,8 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
-          - fedora
+          - fedora37
+          - fedora38
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -39,7 +39,8 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
-          - fedora
+          - fedora37
+          - fedora38
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This collection provides battle tested hardening for:
   - Ubuntu 18.04/20.04/22.04
   - Amazon Linux (some roles supported)
   - Arch Linux (some roles supported)
-  - Fedora (some roles supported)
+  - Fedora 37/38 (some roles supported)
   - Suse Tumbleweed (some roles supported)
 - MySQL
   - MariaDB >= 5.5.65, >= 10.1.45, >= 10.3.17

--- a/roles/ssh_hardening/vars/Fedora_37.yml
+++ b/roles/ssh_hardening/vars/Fedora_37.yml
@@ -1,0 +1,24 @@
+---
+sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: /etc/ssh
+sshd_service_name: sshd
+ssh_owner: root
+ssh_group: root
+ssh_host_keys_owner: root
+ssh_host_keys_group: ssh_keys
+ssh_host_keys_mode: "0600"
+ssh_selinux_packages:
+  - python3-policycoreutils
+  - checkpolicy
+
+# true if SSH support Kerberos
+ssh_kerberos_support: true
+
+# true if SSH has PAM support
+ssh_pam_support: true
+
+sshd_moduli_file: /etc/ssh/moduli
+
+# disable CRYPTO_POLICY to take settings from sshd configuration
+# see: https://access.redhat.com/solutions/4410591
+sshd_disable_crypto_policy: true


### PR DESCRIPTION
Closes https://github.com/dev-sec/ansible-collection-hardening/issues/671.

For Docker testing purposes, this depends on https://github.com/dev-sec/docker-ansible. (will retry once the docker images are available).

/cc @dlouzan 