### PR TITLE
feat: customize user paths default

### DIFF
--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -290,6 +290,11 @@ To prevent some of the filesystems from being disabled, add them to the `os_file
   - Description: true if this is a desktop system, ie Xorg, KDE/GNOME/Unity/etc.
   - Type: bool
   - Required: no
+- `os_env_user_paths`
+  - Default: `[/usr/local/sbin, /usr/local/bin, /usr/sbin, /usr/bin, /sbin, /bin]`
+  - Description: Specify paths to the user's `PATH` variable.
+  - Type: list
+  - Required: no
 - `os_env_extra_user_paths`
   - Default: `"[]"`
   - Description: add additional paths to the user's `PATH` variable (default is empty).

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 os_desktop_enable: false
+os_env_user_paths: [/usr/local/sbin, /usr/local/bin, /usr/sbin, /usr/bin, /sbin, /bin]
 os_env_extra_user_paths: []
 os_auth_pw_max_age: 60
 os_auth_pw_min_age: 7 # Discourage password cycling

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -7,12 +7,7 @@
 - name: Find files with write-permissions for group # noqa command-instead-of-shell
   ansible.builtin.shell: find -L {{ item }} -perm /go+w -type f
   with_community.general.flattened:
-    - /usr/local/sbin
-    - /usr/local/bin
-    - /usr/sbin
-    - /usr/bin
-    - /sbin
-    - /bin
+    - "{{ os_env_user_paths }}"
     - "{{ os_env_extra_user_paths }}"
   register: minimize_access_directories
   ignore_errors: true


### PR DESCRIPTION
Add `os_env_user_paths` variable to customize default user paths.

Resolves: #689