### PR TITLE
Set permissions to host public keys

### DIFF
--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -50,6 +50,26 @@
   ansible.builtin.include_tasks: crypto_kex.yml
   when: not ssh_kex
 
+- name: "Find host public key files"
+  ansible.builtin.find:
+    depth: 1
+    file_type: file
+    paths:
+      - "{{ ssh_host_keys_dir }}"
+    patterns:
+      - "ssh_host_*.pub"
+  when: ssh_server_hardening | bool
+  register: ssh_host_pub_keys
+
+- name: "Change host public key ownership, group and permissions"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    owner: "{{ ssh_host_keys_owner }}"
+    group: "{{ ssh_host_keys_group }}"
+    mode: "{{ ssh_host_pub_keys_mode }}"
+  when: ssh_server_hardening | bool
+  loop: "{{ ssh_host_pub_keys.files }}"
+
 - name: Create revoked_keys and set permissions to root/600
   ansible.builtin.template:
     src: revoked_keys.j2

--- a/roles/ssh_hardening/vars/Amazon_2.yml
+++ b/roles/ssh_hardening/vars/Amazon_2.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Archlinux.yml
+++ b/roles/ssh_hardening/vars/Archlinux.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Debian.yml
+++ b/roles/ssh_hardening/vars/Debian.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/Fedora.yml
+++ b/roles/ssh_hardening/vars/Fedora.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/Fedora_37.yml
+++ b/roles/ssh_hardening/vars/Fedora_37.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - python3-policycoreutils
   - checkpolicy

--- a/roles/ssh_hardening/vars/FreeBSD.yml
+++ b/roles/ssh_hardening/vars/FreeBSD.yml
@@ -7,6 +7,7 @@ ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: wheel
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/OpenBSD.yml
+++ b/roles/ssh_hardening/vars/OpenBSD.yml
@@ -7,6 +7,7 @@ ssh_group: wheel
 ssh_host_keys_owner: root
 ssh_host_keys_group: wheel
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: false

--- a/roles/ssh_hardening/vars/RedHat.yml
+++ b/roles/ssh_hardening/vars/RedHat.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_7.yml
+++ b/roles/ssh_hardening/vars/RedHat_7.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: ssh_keys
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - policycoreutils-python
   - checkpolicy

--- a/roles/ssh_hardening/vars/RedHat_9.yml
+++ b/roles/ssh_hardening/vars/RedHat_9.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 ssh_selinux_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/roles/ssh_hardening/vars/SmartOS.yml
+++ b/roles/ssh_hardening/vars/SmartOS.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true

--- a/roles/ssh_hardening/vars/Suse.yml
+++ b/roles/ssh_hardening/vars/Suse.yml
@@ -7,6 +7,7 @@ ssh_group: root
 ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
+ssh_host_pub_keys_mode: "0644"
 
 # true if SSH support Kerberos
 ssh_kerberos_support: true


### PR DESCRIPTION
In addition to changing permissions to private keys, this also chmods any possible `.pub` equivalents.

Since I'm not sure whether people provide `.pub` files along with their `ssh_host_key_files` this simply finds all of them in the `ssh_host_keys_dir`, which incidentally might be a bit safer anyway. But it is enabled by default once this gets released, happy to hear feedback!

I realize this is not as critical as private keys. Our employer does have a rule for this though, so I thought I'd try to upstream this here.

/cc @dlouzan 

Edit: The codespell failure seems unrelated but I'll keep this in draft