### PR TITLE
docs: restructure variables overview to table

### DIFF
--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -36,96 +36,25 @@ Further information is available at [Deutsche Telekom (German)](http://www.telek
 
 ## Role Variables
 
-- `mysql_daemon_enabled`
-  - Default: `true`
-  - Description: Whether to enable the MySQL-service so it starts on boot
-  - Type: bool
-  - Required: no
-- `mysql_hardening_chroot`
-  - Default: ``
-  - Description: [chroot](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_chroot)
-  - Type: str
-  - Required: no
-- `mysql_hardening_chroot.automatic-sp-privileges`
-  - Default: `0`
-  - Description: [automatic_sp_privileges](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_automatic_sp_privileges)
-  - Type: int
-  - Required: no
-- `mysql_hardening_enabled`
-  - Default: `true`
-  - Description: Whether to run the hardening
-  - Type: bool
-  - Required: no
-- `mysql_hardening_options.allow-suspicious-udfs`
-  - Default: `0`
-  - Description: [allow-suspicious-udfs](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_allow-suspicious-udfs)
-  - Type: int
-  - Required: no
-- `mysql_hardening_options.local-infile`
-  - Default: `0`
-  - Description: [local-infile](http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_local_infile)
-  - Type: int
-  - Required: no
-- `mysql_hardening_options.safe-user-create`
-  - Default: `1`
-  - Description: [safe-user-create](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_safe-user-create)
-  - Type: int
-  - Required: no
-- `mysql_hardening_options.secure-auth`
-  - Default: `1`
-  - Description: [secure-auth](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_secure-auth)
-  - Type: int
-  - Required: no
-- `mysql_hardening_options.secure-file-priv`
-  - Default: `/tmp`
-  - Description: [secure-file-priv](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_secure-file-priv)
-  - Type: str
-  - Required: no
-- `mysql_hardening_options.skip-symbolic-links`
-  - Default: `1`
-  - Description: [skip-symbolic-links](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_symbolic-links)
-  - Type: int
-  - Required: no
-- `mysql_hardening_restart_mysql`
-  - Default: `true`
-  - Description: Restart mysql after running this role
-  - Type: bool
-  - Required: no
-- `mysql_hardening_skip_grant_tables:`
-  - Default: `false`
-  - Description: [skip-grant-tables](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_skip-grant-tables)
-  - Type: bool
-  - Required: no
-- `mysql_hardening_skip_show_database`
-  - Default: `1`
-  - Description: [skip-show-database](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_skip-show-database)
-  - Type: int
-  - Required: no
-- `mysql_remove_anonymous_users`
-  - Default: `true`
-  - Description: Set to `false` to keep users without authentication
-  - Type: bool
-  - Required: no
-- `mysql_remove_remote_root`
-  - Default: `true`
-  - Description: If `true`, root can only connect from localhost. Set to `false` to not remove remote root users.
-  - Type: bool
-  - Required: no
-- `mysql_remove_test_database`
-  - Default: `true`
-  - Description: Set to `false` to keep the test database
-  - Type: bool
-  - Required: no
-- `mysql_root_password`
-  - Default: `-----====>SetR00tPa$$wordH3r3!!!<====-----`
-  - Description: The default password. Please change or overwrite it
-  - Type: str
-  - Required: no
-- `mysql_user_home`
-  - Default: `{{ ansible_env.HOME }}`
-  - Description: The path where the `.my.cnf` will be stored
-  - Type: str
-  - Required: no
+| Variable | Default | Description | Type | Required |
+| -------- | ------- | ----------- | ---- | -------- |
+| `mysql_daemon_enabled` | true | Whether to enable the MySQL-service so it starts on boot | bool | n |
+| `mysql_hardening_chroot.automatic-sp-privileges` | 0 | [automatic_sp_privileges](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_automatic_sp_privileges) | int | n |
+| `mysql_hardening_enabled` | true | Whether to run the hardening | bool | n |
+| `mysql_hardening_options.allow-suspicious-udfs` | 0 | [allow-suspicious-udfs](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_allow-suspicious-udfs) | int | n |
+| `mysql_hardening_options.local-infile` | 0 | [local-infile](http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_local_infile) | int | n |
+| `mysql_hardening_options.safe-user-create` | 1 | [safe-user-create](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_safe-user-create) | int | n |
+| `mysql_hardening_options.secure-auth` | 1 | [secure-auth](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_secure-auth) | int | n |
+| `mysql_hardening_options.secure-file-priv` | /tmp | [secure-file-priv](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_secure-file-priv) | str | n |
+| `mysql_hardening_options.skip-symbolic-links` | 1 | [skip-symbolic-links](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_symbolic-links) | int | n |
+| `mysql_hardening_restart_mysql` | true | Restart mysql after running this role | bool | n |
+| `mysql_hardening_skip_grant_tables:` | false | [skip-grant-tables](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_skip-grant-tables) | bool | n |
+| `mysql_hardening_skip_show_database` | 1 | [skip-show-database](http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_skip-show-database) | int | n |
+| `mysql_remove_anonymous_users` | true | Set to `false` to keep users without authentication | bool | n |
+| `mysql_remove_remote_root` | true | If `true`, root can only connect from localhost. Set to `false` to not remove remote root users. | bool | n |
+| `mysql_remove_test_database` | true | Set to `false` to keep the test database | bool | n |
+| `mysql_root_password` | -----====>SetR00tPa$$wordH3r3!!!<====----- | The default password. Please change or overwrite it | str | n |
+| `mysql_user_home` | {{ ansible_env.HOME }} | The path where the `.my.cnf` will be stored | str | n |
 
 ## Dependencies
 

--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -28,111 +28,29 @@ It works with the following nginx-roles, including, but not limited to:
 
 ## Role Variables
 
-- `nginx_add_header`
-  - Default: `["X-Frame-Options SAMEORIGIN", "X-Content-Type-Options nosniff", "X-XSS-Protection \"1; mode=block\"", "Content-Security-Policy \\\"script-src 'self'; object-src 'self'\\\""]`
-  - Description: Adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307. See [nginx_add_header](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header)
-  - Type: list
-  - Required: no
-- `nginx_client_body_buffer_size`
-  - Default: `1k`
-  - Description: Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. See [nginx_client_body_buffer_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size)
-  - Type: str
-  - Required: no
-- `nginx_client_body_timeout`
-  - Default: `10`
-  - Description: Defines a timeout for reading client request body. See [nginx_client_body_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout)
-  - Type: int
-  - Required: no
-- `nginx_client_header_buffer_size`
-  - Default: `1k`
-  - Description: Sets buffer size for reading client request header. For most requests, a buffer of 1K bytes is enough. See [nginx_client_header_buffer_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client
-  - Type: str
-  - Required: no
-- `nginx_client_header_timeout`
-  - Default: `10`
-  - Description: Defines a timeout for reading client request header. See [nginx_client_header_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout)
-  - Type: int
-  - Required: no
-- `nginx_client_max_body_size`
-  - Default: `1k`
-  - Description: Sets the maximum allowed size of the client request body, specified in the "Content-Length" request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. See [nginx_client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)
-  - Type: str
-  - Required: no
-- `nginx_configuration_dir`
-  - Default: `/etc/nginx`
-  - Description: The main location for all nginx configuration files
-  - Type: str
-  - Required: no
-- `nginx_configuration_hardening_dir`
-  - Default: `/etc/nginx`
-  - Description: The location for the nginx hardening configuration file (Could be different e.g. when used in jails)
-  - Type: str
-  - Required: no
-- `nginx_dh_size`
-  - Default: `2048`
-  - Description: Specifies the length of DH parameters for EDH ciphers. See [nginx_dh_size](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam)
-  - Type: int
-  - Required: no
-- `nginx_keepalive_timeout`
-  - Default: `5 5`
-  - Description: The first parameter sets a timeout during which a keep-alive client connection will stay open on the server side. The zero value disables keep-alive client connections. The optional second parameter sets a value in the "Keep-Alive timeout=time" response header field. See [nginx_keepalive_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)
-  - Type: str
-  - Required: no
-- `nginx_large_client_header_buffers`
-  - Default: `2 1k`
-  - Description: Sets the maximum number and size of buffers used for reading large client request header. See [nginx_large_client_header_buffers](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
-  - Type: str
-  - Required: no
-- `nginx_limit_conn`
-  - Default: `default 5`
-  - Description: Sets the shared memory zone and the maximum allowed number of connections for a given key value. See [nginx_limit_conn](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn)
-  - Type: str
-  - Required: no
-- `nginx_limit_conn_zone`
-  - Default: `$binary_remote_addr zone=default:10m`
-  - Description: Sets parameters for a shared memory zone that will keep states for various keys. See [nginx_limit_conn_zone](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone)
-  - Type: str
-  - Required: no
-- `nginx_owner_group`
-  - Default: `root`
-  - Description: The owner group of the nginx configuration files
-  - Type: str
-  - Required: no
-- `nginx_owner_user`
-  - Default: `root`
-  - Description: The owner user of the nginx configuration files
-  - Type: str
-  - Required: no
-- `nginx_remove_default_site`
-  - Default: `true`
-  - Description: Disables the default site. Set to false to enable the default site in nginx.
-  - Type: bool
-  - Required: no
-- `nginx_send_timeout`
-  - Default: `10`
-  - Description: Sets a timeout for transmitting a response to the client. See [nginx_send_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout)
-  - Type: int
-  - Required: no
-- `nginx_server_tokens`
-  - Default: `off`
-  - Description: Disables emitting nginx version in error messages and in the "Server" response header field. Set to on to enable the nginx version in error messages and "Server" response header. See [nginx_server_tokens](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens)
-  - Type: str
-  - Required: no
-- `nginx_ssl_ciphers`
-  - Default: `ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256`
-  - Description: Specifies the TLS ciphers which should be used. See [nginx_ssl_ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers)
-  - Type: str
-  - Required: no
-- `nginx_ssl_prefer_server_ciphers`
-  - Default: `on`
-  - Description: Specifies that server ciphers should be preferred over client ciphers when using the TLS protocols. Set to false to disable it. See [nginx_ssl_prefer_server_ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers)
-  - Type: str
-  - Required: no
-- `nginx_ssl_protocols`
-  - Default: `TLSv1.2`
-  - Description: Specifies the SSL protocol which should be used. See [nginx_ssl_protocols](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols)
-  - Type: str
-  - Required: no
+| Variable | Default | Description | Type | Required |
+| -------- | ------- | ----------- | ---- | -------- |
+| `nginx_add_header` | ["X-Frame-Options SAMEORIGIN", "X-Content-Type-Options nosniff", "X-XSS-Protection "1; mode=block"", "Content-Security-Policy \"script-src 'self'; object-src 'self'\""] | Adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307. See [nginx_add_header](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) | list | n |
+| `nginx_client_body_buffer_size` | 1k | Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. See [nginx_client_body_buffer_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) | str | n |
+| `nginx_client_body_timeout` | 10 | Defines a timeout for reading client request body. See [nginx_client_body_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout) | int | n |
+| `nginx_client_header_buffer_size` | 1k | Sets buffer size for reading client request header. For most requests, a buffer of 1K bytes is enough. See [nginx_client_header_buffer_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client | str | n |
+| `nginx_client_header_timeout` | 10 | Defines a timeout for reading client request header. See [nginx_client_header_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout) | int | n |
+| `nginx_client_max_body_size` | 1k | Sets the maximum allowed size of the client request body, specified in the "Content-Length" request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. See [nginx_client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) | str | n |
+| `nginx_configuration_dir` | /etc/nginx | The main location for all nginx configuration files | str | n |
+| `nginx_configuration_hardening_dir` | /etc/nginx | The location for the nginx hardening configuration file (Could be different e.g. when used in jails) | str | n |
+| `nginx_dh_size` | 2048 | Specifies the length of DH parameters for EDH ciphers. See [nginx_dh_size](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam) | int | n |
+| `nginx_keepalive_timeout` | 5 5 | The first parameter sets a timeout during which a keep-alive client connection will stay open on the server side. The zero value disables keep-alive client connections. The optional second parameter sets a value in the "Keep-Alive timeout=time" response header field. See [nginx_keepalive_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout) | str | n |
+| `nginx_large_client_header_buffers` | 2 1k | Sets the maximum number and size of buffers used for reading large client request header. See [nginx_large_client_header_buffers](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) | str | n |
+| `nginx_limit_conn` | default 5 | Sets the shared memory zone and the maximum allowed number of connections for a given key value. See [nginx_limit_conn](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn) | str | n |
+| `nginx_limit_conn_zone` | $binary_remote_addr zone=default:10m | Sets parameters for a shared memory zone that will keep states for various keys. See [nginx_limit_conn_zone](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone) | str | n |
+| `nginx_owner_group` | root | The owner group of the nginx configuration files | str | n |
+| `nginx_owner_user` | root | The owner user of the nginx configuration files | str | n |
+| `nginx_remove_default_site` | true | Disables the default site. Set to false to enable the default site in nginx. | bool | n |
+| `nginx_send_timeout` | 10 | Sets a timeout for transmitting a response to the client. See [nginx_send_timeout](http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout) | int | n |
+| `nginx_server_tokens` | off | Disables emitting nginx version in error messages and in the "Server" response header field. Set to on to enable the nginx version in error messages and "Server" response header. See [nginx_server_tokens](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) | str | n |
+| `nginx_ssl_ciphers` | ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256 | Specifies the TLS ciphers which should be used. See [nginx_ssl_ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers) | str | n |
+| `nginx_ssl_prefer_server_ciphers` | on | Specifies that server ciphers should be preferred over client ciphers when using the TLS protocols. Set to false to disable it. See [nginx_ssl_prefer_server_ciphers](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers) | str | n |
+| `nginx_ssl_protocols` | TLSv1.2 | Specifies the SSL protocol which should be used. See [nginx_ssl_protocols](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols) | str | n |
 
 ## Dependencies
 

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -71,846 +71,176 @@ To prevent some of the filesystems from being disabled, add them to the `os_file
 
 ## Role Variables
 
-- `os_apt_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring apt.
-  - Type: bool
-  - Required: no
-- `os_auditd_action_mail_acct`
-  - Default: `root`
-  - Description: If `space_left_action` or `admin_space_left_action` are set to `email`, uses the address or alias to send the email using `/usr/lib/sendmail`. of events created on one system but reported/analyzed on another system.
-  - Type: str
-  - Required: no
-- `os_auditd_admin_space_left`
-  - Default: `50`
-  - Description: This is a numeric value in megabytes that tells the audit daemon when to perform a configurable action because the system is running low on disk space.
-  - Type: int
-  - Required: no
-- `os_auditd_admin_space_left_action`
-  - Default: `SUSPEND`
-  - Description: This parameter tells the system what action to take when the system has detected that it is low on disk space. Valid values are ignore, syslog, rotate, email, exec, suspend, single, and halt.
-  - Type: str
-  - Required: no
-- `os_auditd_disk_error_action`
-  - Default: `SUSPEND`
-  - Description: This parameter tells the system what action to take whenever there is an error detected when writing audit events to disk or rotating logs. Valid values are ignore, syslog, exec, suspend, single, and halt.
-  - Type: str
-  - Required: no
-- `os_auditd_disk_full_action`
-  - Default: `SUSPEND`
-  - Description: This parameter tells the system what action to take when the system has detected that the partition to which log files are written has become full. Valid values are ignore, syslog, rotate, exec, suspend, single, and halt.
-  - Type: str
-  - Required: no
-- `os_auditd_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring auditd.
-  - Type: bool
-  - Required: no
-- `os_auditd_flush`
-  - Default: `INCREMENTAL`
-  - Description: Valid values are none, incremental, incremental_async, data, and sync.
-  - Type: str
-  - Required: no
-- `os_auditd_log_format`
-  - Default: `RAW`
-  - Description: Describes how the information should be stored on disk. There are 2 options - raw and enriched.
-  - Type: str
-  - Required: no
-- `os_auditd_log_group`
-  - Default: `root`
-  - Description: specifies the group that is applied to the log file's permissions. The group name can be either numeric or spelled out.
-  - Type: str
-  - Required: no
-- `os_auditd_max_log_file`
-  - Default: `6`
-  - Description: This keyword specifies the maximum file size in megabytes. When this limit is reached, it will trigger a configurable action. The value given must be numeric.
-  - Type: int
-  - Required: no
-- `os_auditd_max_log_file_action`
-  - Default: `keep_logs`
-  - Description: Defines the behaviour of auditd when its log file is filled up. Possible other values are described in the auditd.conf man page. The most common alternative to the default may be `rotate`.
-  - Type: str
-  - Required: no
-- `os_auditd_num_logs`
-  - Default: `5`
-  - Description: This keyword specifies the number of log files to keep if `rotate` is given as the max_log_file_action. The value given must be numeric.
-  - Type: int
-  - Required: no
-- `os_auditd_space_left`
-  - Default: `75`
-  - Description: If the free space in the filesystem containing log_file drops below this value, the audit daemon takes the action specified by space_left_action.
-  - Type: int
-  - Required: no
-- `os_auditd_space_left_action`
-  - Default: `SYSLOG`
-  - Description: This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space. Valid values are ignore, syslog, rotate, email, exec, suspend, single, and halt.
-  - Type: str
-  - Required: no
-- `os_auth_allow_homeless`
-  - Default: `false`
-  - Description: true if to allow users without home to login.
-  - Type: bool
-  - Required: no
-- `os_auth_gid_max`
-  - Default: `60000`
-  - Description: maximum number for automatic gid selection in groupadd.
-  - Type: int
-  - Required: no
-- `os_auth_gid_min`
-  - Default: `1000`
-  - Description: minimum number for automatic gid selection in groupadd.
-  - Type: int
-  - Required: no
-- `os_auth_lockout_time`
-  - Default: `600`
-  - Description: time in seconds that needs to pass, if the account was locked due to too many failed authentication attempts.
-  - Type: int
-  - Required: no
-- `os_auth_pam_oddjob_mkhomedir`
-  - Default: `false`
-  - Description: Enables automatic homedir e.g. in FreeIPA environments
-  - Type: bool
-  - Required: no
-- `os_auth_pam_passwdqc_enable`
-  - Default: `true`
-  - Description: true if you want to use strong password checking in PAM using passwdqc.
-  - Type: bool
-  - Required: no
-- `os_auth_pam_passwdqc_options`
-  - Default: `min=disabled,disabled,16,12,8`
-  - Description: set to any option line (as a string) that you want to pass to passwdqc.
-  - Type: str
-  - Required: no
-- `os_auth_pam_pwquality_options`
-  - Default: `try_first_pass retry=3 authtok_type=`
-  - Description: Options to pass to the PAM module pwquality
-  - Type: str
-  - Required: no
-- `os_auth_pw_max_age`
-  - Default: `60`
-  - Description: maximum password age (set to `99999` to effectively disable it).
-  - Type: int
-  - Required: no
-- `os_auth_pw_min_age`
-  - Default: `7`
-  - Description: minimum password age (before allowing any other password change).
-  - Type: int
-  - Required: no
-- `os_auth_pw_remember`
-  - Default: `5`
-  - Description: how many used passwords are record.
-  - Type: int
-  - Required: no
-- `os_auth_pw_warn_age`
-  - Default: `7`
-  - Description: number of days of warning before password expires.
-  - Type: int
-  - Required: no
-- `os_auth_retries`
-  - Default: `5`
-  - Description: the maximum number of authentication attempts, before the account is locked for some time.
-  - Type: int
-  - Required: no
-- `os_auth_root_ttys`
-  - Default: `["console", "tty1", "tty2", "tty3", "tty4", "tty5", "tty6"]`
-  - Description: A list of TTYs, from which root can log in, see `man securetty` for reference
-  - Type: list
-  - Required: no
-- `os_auth_sub_gid_count`
-  - Default: `65536`
-  - Description: If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate group IDs) allocate SUB_GID_COUNT unused group IDs from the range SUB_GID_MIN to SUB_GID_MAX for each new user. See also `os_auth_sub_gid_min` and `os_auth_sub_gid_max`.
-  - Type: int
-  - Required: no
-- `os_auth_sub_gid_max`
-  - Default: `600100000`
-  - Description: maximum number for automatic subordinate gid selection in useradd and newusers.
-  - Type: int
-  - Required: no
-- `os_auth_sub_gid_min`
-  - Default: `100000`
-  - Description: minimum number for automatic subordinate gid selection in useradd and newusers.
-  - Type: int
-  - Required: no
-- `os_auth_sub_uid_count`
-  - Default: `65536`
-  - Description: If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate user IDs) allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user. See also `os_auth_sub_uid_min` and `os_auth_sub_uid_max`.
-  - Type: int
-  - Required: no
-- `os_auth_sub_uid_max`
-  - Default: `600100000`
-  - Description: maximum number for automatic subordinate uid selection in useradd and newusers.
-  - Type: int
-  - Required: no
-- `os_auth_sub_uid_min`
-  - Default: `100000`
-  - Description: minimum number for automatic subordinate uid selection in useradd and newusers.
-  - Type: int
-  - Required: no
-- `os_auth_timeout`
-  - Default: `60`
-  - Description: authentication timeout in seconds, so login will exit if this time passes.
-  - Type: int
-  - Required: no
-- `os_auth_uid_max`
-  - Default: `60000`
-  - Description: maximum number for automatic uid selection in useradd.
-  - Type: int
-  - Required: no
-- `os_auth_uid_min`
-  - Default: `1000`
-  - Description: minimum number for automatic uid selection in useradd.
-  - Type: int
-  - Required: no
-- `os_chfn_restrict`
-  - Default: `''`
-  - Description: Indicate which fields are changeable by chfn.
-  - Type: str
-  - Required: no
-- `os_chmod_home_folders`
-  - Default: `true`
-  - Description: Set to `false` to disable "chmod 700" of home folders for regular users
-  - Type: bool
-  - Required: no
-- `os_chmod_rootuser_home_folder`
-  - Default: `true`
-  - Description: Set to `false` to disable "chmod 700" of root's home folder
-  - Type: bool
-  - Required: no
-- `os_cron_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring cron.
-  - Type: bool
-  - Required: no
-- `os_ctrlaltdel_disabled`
-  - Default: `false`
-  - Description: Set to true to disable ctrl-alt-delete key combination.
-  - Type: bool
-  - Required: no
-- `os_desktop_enable`
-  - Default: `false`
-  - Description: true if this is a desktop system, ie Xorg, KDE/GNOME/Unity/etc.
-  - Type: bool
-  - Required: no
-- `os_env_extra_user_paths`
-  - Default: `"[]"`
-  - Description: Specify additional paths that should be checked for binaries where access will be minimized
-  - Type: list
-  - Required: no
-- `os_env_user_paths`
-  - Default: `["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]`
-  - Description: Specify paths that should be checked for binaries where access will be minimized
-  - Type: list
-  - Required: no
-- `os_filesystem_whitelist`
-  - Default: `"[]"`
-  - Description: A list of filesystems that should not be disabled
-  - Type: list
-  - Required: no
-- `os_hardening_enabled`
-  - Default: `true`
-  - Description: Whether to run the hardening
-  - Type: bool
-  - Required: no
-- `os_ignore_home_folder_users`
-  - Default: `"[]"`
-  - Description: Specify user accounts, whose home folders shouldn't be chmodded to 700 when "os_chmod_home_folders" is enabled.
-  - Type: list
-  - Required: no
-- `os_ignore_users`
-  - Default: `["vagrant", "kitchen"]`
-  - Description: Specify system accounts whose login should not be disabled and password not changed
-  - Type: list
-  - Required: no
-- `os_limits_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring limits.
-  - Type: bool
-  - Required: no
-- `os_login_defs_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring login_defs for newly created users.
-  - Type: bool
-  - Required: no
-- `os_minimize_access_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring minimize_access.
-  - Type: bool
-  - Required: no
-- `os_mnt_boot_dir_mode`
-  - Default: `0700`
-  - Description: Set default perimissions for /boot
-  - Type: str
-  - Required: no
-- `os_mnt_boot_dump`
-  - Default: `ext3 + ext4 = 1 / other = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_boot_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /boot mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_boot_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /boot. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_boot_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /boot
-  - Type: str
-  - Required: no
-- `os_mnt_boot_passno`
-  - Default: `ext3 + ext4 = 2 / other = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_boot_src`
-  - Default: `''`
-  - Description: Set mount source for /boot
-  - Type: str
-  - Required: no
-- `os_mnt_dev_dir_mode`
-  - Default: `0755`
-  - Description: Set default perimissions for /dev
-  - Type: str
-  - Required: no
-- `os_mnt_dev_dump`
-  - Default: `0`
-  - Description: Configure dump for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_dev_enabled`
-  - Default: `true`
-  - Description: Set to false to ignore /dev mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_dev_filesystem`
-  - Default: `devtmpfs`
-  - Description: Configure file system for fstab entry /dev
-  - Type: str
-  - Required: no
-- `os_mnt_dev_options`
-  - Default: `rw,nosuid,noexec`
-  - Description: Configure mount options for /dev
-  - Type: str
-  - Required: no
-- `os_mnt_dev_passno`
-  - Default: `0`
-  - Description: Configure passno for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_dir_mode`
-  - Default: `1777`
-  - Description: Set default perimissions for /dev/shm
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_dump`
-  - Default: `0`
-  - Description: Configure dump for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_enabled`
-  - Default: `true`
-  - Description: Set to false to ignore /dev/shm mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_dev_shm_filesystem`
-  - Default: `tmpfs`
-  - Description: Configure file system for fstab entry /dev/shm
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /dev/shm
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_passno`
-  - Default: `0`
-  - Description: Configure passno for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_dev_shm_src`
-  - Default: `tmpfs`
-  - Description: Set mount source for /dev/shm
-  - Type: str
-  - Required: no
-- `os_mnt_dev_src`
-  - Default: `devtmpfs`
-  - Description: Set mount source for /dev
-  - Type: str
-  - Required: no
-- `os_mnt_home_dir_mode`
-  - Default: `0755`
-  - Description: Set default perimissions for /home
-  - Type: str
-  - Required: no
-- `os_mnt_home_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_home_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /home mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_home_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /home. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_home_options`
-  - Default: `rw,nosuid,nodev`
-  - Description: Configure mount options for /home
-  - Type: str
-  - Required: no
-- `os_mnt_home_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_home_src`
-  - Default: `''`
-  - Description: Set mount source for /home. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_run_dir_mode`
-  - Default: `0755`
-  - Description: Set default perimissions for /run
-  - Type: str
-  - Required: no
-- `os_mnt_run_dump`
-  - Default: `0`
-  - Description: Configure dump for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_run_enabled`
-  - Default: `true`
-  - Description: Set to false to ignore /run mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_run_filesystem`
-  - Default: `tmpfs`
-  - Description: Configure file system for fstab entry /run
-  - Type: str
-  - Required: no
-- `os_mnt_run_options`
-  - Default: `rw,nosuid,nodev`
-  - Description: Configure mount options for /run
-  - Type: str
-  - Required: no
-- `os_mnt_run_passno`
-  - Default: `0`
-  - Description: Configure passno for fstab entry /var/tmp.
-  - Type: str
-  - Required: no
-- `os_mnt_run_src`
-  - Default: `tmpfs`
-  - Description: Set mount source for /run
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_dir_mode`
-  - Default: `1777`
-  - Description: Set default perimissions for /tmp
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /tmp mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_tmp_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /tmp. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /tmp
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_tmp_src`
-  - Default: `''`
-  - Description: Set mount source for /tmp. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_dir_mode`
-  - Default: `0755`
-  - Description: Set default perimissions for /var
-  - Type: str
-  - Required: no
-- `os_mnt_var_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /var mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_var_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /var. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_dir_mode`
-  - Default: `0640`
-  - Description: Set default perimissions for /var/log/audit
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /var/log/audit mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_var_log_audit_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /var/log/audit. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /var/log/audit
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_audit_src`
-  - Default: `''`
-  - Description: Set mount source for /var/log/audit. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_dir_mode`
-  - Default: `0755`
-  - Description: Set default perimissions for /var/log
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /var/log mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_var_log_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /var/log. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /var/log
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_log_src`
-  - Default: `''`
-  - Description: Set mount source for /var/log. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_options`
-  - Default: `rw,nosuid,nodev`
-  - Description: Configure mount options for /var
-  - Type: str
-  - Required: no
-- `os_mnt_var_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_src`
-  - Default: `''`
-  - Description: Set mount source for /var. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_dir_mode`
-  - Default: `1777`
-  - Description: Set default perimissions for /var/tmp
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_dump`
-  - Default: `ext3/4 = 1, others = 0`
-  - Description: Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_enabled`
-  - Default: `false`
-  - Description: Set to true to configure /var/tmp mountpoint
-  - Type: bool
-  - Required: no
-- `os_mnt_var_tmp_filesystem`
-  - Default: `''`
-  - Description: Configure file system for fstab entry /var/tmp. If empty, the current file system type will be used.
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_options`
-  - Default: `rw,nosuid,nodev,noexec`
-  - Description: Configure mount options for /var/tmp
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_passno`
-  - Default: `ext3/4 = 2, others = 0`
-  - Description: Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype.
-  - Type: str
-  - Required: no
-- `os_mnt_var_tmp_src`
-  - Default: `''`
-  - Description: Set mount source for /var/tmp. If empty, the current file system source device will be used.
-  - Type: str
-  - Required: no
-- `os_modprobe_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring modprobe.
-  - Type: bool
-  - Required: no
-- `os_netrc_enabled`
-  - Default: `true`
-  - Description: Configure filesystem for existence of .netrc file in homedir
-  - Type: bool
-  - Required: no
-- `os_netrc_whitelist_user`
-  - Default: `"[]"`
-  - Description: Add list of user to allow creation of .netrc in users homedir
-  - Type: list
-  - Required: no
-- `os_pam_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring pam.
-  - Type: bool
-  - Required: no
-- `os_profile_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring profile.
-  - Type: bool
-  - Required: no
-- `os_remove_additional_root_users`
-  - Default: `false`
-  - Description: When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted.
-  - Type: bool
-  - Required: no
-- `os_rhosts_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring rhosts.
-  - Type: bool
-  - Required: no
-- `os_rootuser_pw_ageing`
-  - Default: `false`
-  - Description: Set to true to enforce password age settings for root user(s)
-  - Type: bool
-  - Required: no
-- `os_securetty_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring securetty.
-  - Type: bool
-  - Required: no
-- `os_security_auto_logout`
-  - Default: `0`
-  - Description: Set timeout in seconds for logout users automatically after time. Setting this to `0` disables the timeout.
-  - Type: int
-  - Required: no
-- `os_security_init_prompt`
-  - Default: `true`
-  - Description: The PROMPT option provides console users the ability to interactively boot the system and select which services to start on boot.
-  - Type: bool
-  - Required: no
-- `os_security_init_single`
-  - Default: `false`
-  - Description: Single-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup. By default, no authentication is performed if single-user mode is selected. To require entry of the root password even if the system is started in single-user mode, set this to false
-  - Type: bool
-  - Required: no
-- `os_security_kernel_enable_core_dump`
-  - Default: `false`
-  - Description: kernel is crashing or otherwise misbehaving and a kernel core dump is created.
-  - Type: bool
-  - Required: no
-- `os_security_kernel_enable_module_loading`
-  - Default: `true`
-  - Description: true if you want to allowed to change kernel modules once the system is running (eg `modprobe`, `rmmod`). WARNING - Rebuilding initramfs is deprecated and will be removed in the next major release. For more information take a look at this issue <https://github.com/dev-sec/ansible-collection-hardening/pull/591>
-  - Type: bool
-  - Required: no
-- `os_security_packages_clean`
-  - Default: `true`
-  - Description: removes packages with known issues. See section packages.
-  - Type: bool
-  - Required: no
-- `os_security_packages_list`
-  - Default: `["xinetd", "inetd", "ypserv", "telnet-server", "rsh-server", "prelink"]`
-  - Description: List of deprecated or insecure packages to remove
-  - Type: list
-  - Required: no
-- `os_security_suid_sgid_blacklist`
-  - Default: `"[]"`
-  - Description: a list of paths which should have their SUID/SGID bits removed.
-  - Type: list
-  - Required: no
-- `os_security_suid_sgid_enforce`
-  - Default: `true`
-  - Description: true if you want to reduce SUID/SGID bits. There is already a list of items which are searched for configured, but you can also add your own.
-  - Type: bool
-  - Required: no
-- `os_security_suid_sgid_remove_from_unknown`
-  - Default: `false`
-  - Description: true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Ansible-run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
-  - Type: bool
-  - Required: no
-- `os_security_suid_sgid_whitelist`
-  - Default: `"[]"`
-  - Description: a list of paths which should not have their SUID/SGID bits altered.
-  - Type: list
-  - Required: no
-- `os_security_users_allow`
-  - Default: `"[]"`
-  - Description: list of things, that a user is allowed to do. May contain `change_user`.
-  - Type: list
-  - Required: no
-- `os_selinux_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring selinux.
-  - Type: bool
-  - Required: no
-- `os_selinux_policy`
-  - Default: `targeted`
-  - Description: Set the SELinux polixy.
-  - Type: str
-  - Required: no
-- `os_selinux_state`
-  - Default: `enforcing`
-  - Description: Set the SELinux state, can be either disabled, permissive, or enforcing.
-  - Type: str
-  - Required: no
-- `os_sha_crypt_max_rounds`
-  - Default: `640000`
-  - Description: Define the number of maximum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range.
-  - Type: int
-  - Required: no
-- `os_sha_crypt_min_rounds`
-  - Default: `640000`
-  - Description: Define the number of minimum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range.
-  - Type: int
-  - Required: no
-- `os_sysctl_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring sysctl.
-  - Type: bool
-  - Required: no
-- `os_unused_filesystems`
-  - Default: `["cramfs", "freevxfs", "jffs2", "hfs", "hfsplus", "squashfs", "udf", "vfat", "dccp", "rds", "sctp", "tipc"]`
-  - Description: Disable this list of unused filesystems
-  - Type: list
-  - Required: no
-- `os_user_accounts_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring user_accounts.
-  - Type: bool
-  - Required: no
-- `os_user_pw_ageing`
-  - Default: `true`
-  - Description: Set to false to disable password age enforcement on existing users
-  - Type: bool
-  - Required: no
-- `os_users_without_password_ageing`
-  - Default: `"[]"`
-  - Description: List of users, where password ageing should not be enforced even if "os_user_pw_ageing" is enabled
-  - Type: list
-  - Required: no
-- `os_yum_enabled`
-  - Default: `true`
-  - Description: Set to false to disable installing and configuring yum.
-  - Type: bool
-  - Required: no
-- `os_yum_repo_file_whitelist`
-  - Default: `"[]"`
-  - Description: List of yum repository files under /etc/yum.repos.d/ which should not be altered.
-  - Type: list
-  - Required: no
-- `proc_mnt_options`
-  - Default: `rw,nosuid,nodev,noexec,relatime`
-  - Description: Mount proc with hardenized options. Note that the hidepid option is set separately in vars/.
-  - Type: str
-  - Required: no
-- `sysctl_config`
-  - Default: `{"fs.protected_hardlinks": 1, "fs.protected_symlinks": 1, "fs.protected_fifos": 1, "fs.protected_regular": 2, "fs.suid_dumpable": 0, "kernel.core_uses_pid": 1, "kernel.kptr_restrict": 2, "kernel.kexec_load_disabled": 1, "kernel.sysrq": 0, "kernel.randomize_va_space": 2, "kernel.yama.ptrace_scope": 1, "net.ipv4.ip_forward": 0, "net.ipv6.conf.all.forwarding": 0, "net.ipv4.conf.all.rp_filter": 1, "net.ipv4.conf.default.rp_filter": 1, "net.ipv4.icmp_echo_ignore_broadcasts": 1, "net.ipv4.icmp_ignore_bogus_error_responses": 1, "net.ipv4.icmp_ratelimit": 100, "net.ipv4.icmp_ratemask": 88089, "net.ipv4.tcp_timestamps": 0, "net.ipv4.conf.all.arp_ignore": 1, "net.ipv4.conf.all.arp_announce": 2, "net.ipv4.tcp_rfc1337": 1, "net.ipv4.tcp_syncookies": 1, "net.ipv4.conf.all.shared_media": 1, "net.ipv4.conf.default.shared_media": 1, "net.ipv4.conf.all.accept_source_route": 0, "net.ipv4.conf.default.accept_source_route": 0, "net.ipv6.conf.all.accept_source_route": 0, "net.ipv6.conf.default.accept_source_route": 0, "net.ipv4.conf.all.send_redirects": 0, "net.ipv4.conf.default.send_redirects": 0, "net.ipv4.conf.all.log_martians": 1, "net.ipv4.conf.default.log_martians": 1, "net.ipv4.conf.default.accept_redirects": 0, "net.ipv4.conf.all.accept_redirects": 0, "net.ipv4.conf.all.secure_redirects": 0, "net.ipv4.conf.default.secure_redirects": 0, "net.ipv6.conf.default.accept_redirects": 0, "net.ipv6.conf.all.accept_redirects": 0, "net.ipv6.conf.all.accept_ra": 0, "net.ipv6.conf.default.accept_ra": 0, "net.ipv6.conf.default.router_solicitations": 0, "net.ipv6.conf.all.router_solicitations": 0, "net.ipv6.conf.default.accept_ra_rtr_pref": 0, "net.ipv6.conf.default.accept_ra_pinfo": 0, "net.ipv6.conf.default.accept_ra_defrtr": 0, "net.ipv6.conf.default.autoconf": 0, "net.ipv6.conf.all.autoconf": 0, "net.ipv6.conf.default.dad_transmits": 0, "net.ipv6.conf.default.max_addresses": 1, "vm.mmap_min_addr": 65536, "vm.mmap_rnd_bits": 32, "vm.mmap_rnd_compat_bits": 16}`
-  - Description: various sysctl-settings
-  - Type: dict
-  - Required: no
-- `sysctl_overwrite`
-  - Default: `"{}"`
-  - Description: To overwrite options in the `sysctl_config`-dict, overwrite them here.
-  - Type: dict
-  - Required: no
-- `ufw_default_application_policy`
-  - Default: `SKIP`
-  - Description: The default application policy is skip, which means that the update --add-new command will do nothing
-  - Type: str
-  - Required: no
-- `ufw_default_forward_policy`
-  - Default: `DROP`
-  - Description: set default forward policy of ufw to `DROP`.
-  - Type: str
-  - Required: no
-- `ufw_default_input_policy`
-  - Default: `DROP`
-  - Description: set default input policy of ufw to `DROP`.
-  - Type: str
-  - Required: no
-- `ufw_default_output_policy`
-  - Default: `ACCEPT`
-  - Description: set default output policy of ufw to `ACCEPT`.
-  - Type: str
-  - Required: no
-- `ufw_enable_ipv6`
-  - Default: `true`
-  - Description: Set to `true` to apply rules to support IPv6 (no means only IPv6 on loopback accepted).
-  - Type: bool
-  - Required: no
-- `ufw_ipt_modules`
-  - Default: `nf_conntrack_ftp nf_nat_ftp nf_conntrack_netbios_ns`
-  - Description: Define which netfilter modules to load
-  - Type: str
-  - Required: no
-- `ufw_ipt_sysctl`
-  - Default: `''`
-  - Description: by default it disables IPT_SYSCTL in /etc/default/ufw. If you want to overwrite /etc/sysctl.conf values using ufw - set it to your sysctl dictionary, for example `/etc/ufw/sysctl.conf`.
-  - Type: str
-  - Required: no
-- `ufw_manage_builtins`
-  - Default: `no`
-  - Description: If this variable is set to 'yes', on stop and reload the built-in chains are flushed. If it is set to 'no', on stop and reload the ufw secondary chains are removed and the ufw primary chains are flushed
-  - Type: str
-  - Required: no
-- `ufw_manage_defaults`
-  - Default: `true`
-  - Description: true means apply all settings with `ufw_` prefix.
-  - Type: bool
-  - Required: no
+| Variable | Default | Description | Type | Required |
+| -------- | ------- | ----------- | ---- | -------- |
+| `os_apt_enabled` | true | Set to false to disable installing and configuring apt. | bool | n |
+| `os_auditd_action_mail_acct` | root | If `space_left_action` or `admin_space_left_action` are set to `email`, uses the address or alias to send the email using `/usr/lib/sendmail`. of events created on one system but reported/analyzed on another system. | str | n |
+| `os_auditd_admin_space_left` | 50 | This is a numeric value in megabytes that tells the audit daemon when to perform a configurable action because the system is running low on disk space. | int | n |
+| `os_auditd_admin_space_left_action` | SUSPEND | This parameter tells the system what action to take when the system has detected that it is low on disk space. Valid values are ignore, syslog, rotate, email, exec, suspend, single, and halt. | str | n |
+| `os_auditd_disk_error_action` | SUSPEND | This parameter tells the system what action to take whenever there is an error detected when writing audit events to disk or rotating logs. Valid values are ignore, syslog, exec, suspend, single, and halt. | str | n |
+| `os_auditd_disk_full_action` | SUSPEND | This parameter tells the system what action to take when the system has detected that the partition to which log files are written has become full. Valid values are ignore, syslog, rotate, exec, suspend, single, and halt. | str | n |
+| `os_auditd_enabled` | true | Set to false to disable installing and configuring auditd. | bool | n |
+| `os_auditd_flush` | INCREMENTAL | Valid values are none, incremental, incremental_async, data, and sync. | str | n |
+| `os_auditd_log_format` | RAW | Describes how the information should be stored on disk. There are 2 options - raw and enriched. | str | n |
+| `os_auditd_log_group` | root | specifies the group that is applied to the log file's permissions. The group name can be either numeric or spelled out. | str | n |
+| `os_auditd_max_log_file` | 6 | This keyword specifies the maximum file size in megabytes. When this limit is reached, it will trigger a configurable action. The value given must be numeric. | int | n |
+| `os_auditd_max_log_file_action` | keep_logs | Defines the behaviour of auditd when its log file is filled up. Possible other values are described in the auditd.conf man page. The most common alternative to the default may be `rotate`. | str | n |
+| `os_auditd_num_logs` | 5 | This keyword specifies the number of log files to keep if `rotate` is given as the max_log_file_action. The value given must be numeric. | int | n |
+| `os_auditd_space_left` | 75 | If the free space in the filesystem containing log_file drops below this value, the audit daemon takes the action specified by space_left_action. | int | n |
+| `os_auditd_space_left_action` | SYSLOG | This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space. Valid values are ignore, syslog, rotate, email, exec, suspend, single, and halt. | str | n |
+| `os_auth_allow_homeless` | false | true if to allow users without home to login. | bool | n |
+| `os_auth_gid_max` | 60000 | maximum number for automatic gid selection in groupadd. | int | n |
+| `os_auth_gid_min` | 1000 | minimum number for automatic gid selection in groupadd. | int | n |
+| `os_auth_lockout_time` | 600 | time in seconds that needs to pass, if the account was locked due to too many failed authentication attempts. | int | n |
+| `os_auth_pam_oddjob_mkhomedir` | false | Enables automatic homedir e.g. in FreeIPA environments | bool | n |
+| `os_auth_pam_passwdqc_enable` | true | true if you want to use strong password checking in PAM using passwdqc. | bool | n |
+| `os_auth_pam_passwdqc_options` | min=disabled,disabled,16,12,8 | set to any option line (as a string) that you want to pass to passwdqc. | str | n |
+| `os_auth_pam_pwquality_options` | try_first_pass retry=3 authtok_type= | Options to pass to the PAM module pwquality | str | n |
+| `os_auth_pw_max_age` | 60 | maximum password age (set to `99999` to effectively disable it). | int | n |
+| `os_auth_pw_min_age` | 7 | minimum password age (before allowing any other password change). | int | n |
+| `os_auth_pw_remember` | 5 | how many used passwords are record. | int | n |
+| `os_auth_pw_warn_age` | 7 | number of days of warning before password expires. | int | n |
+| `os_auth_retries` | 5 | the maximum number of authentication attempts, before the account is locked for some time. | int | n |
+| `os_auth_root_ttys` | ["console", "tty1", "tty2", "tty3", "tty4", "tty5", "tty6"] | A list of TTYs, from which root can log in, see `man securetty` for reference | list | n |
+| `os_auth_sub_gid_count` | 65536 | If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate group IDs) allocate SUB_GID_COUNT unused group IDs from the range SUB_GID_MIN to SUB_GID_MAX for each new user. See also `os_auth_sub_gid_min` and `os_auth_sub_gid_max`. | int | n |
+| `os_auth_sub_gid_max` | 600100000 | maximum number for automatic subordinate gid selection in useradd and newusers. | int | n |
+| `os_auth_sub_gid_min` | 100000 | minimum number for automatic subordinate gid selection in useradd and newusers. | int | n |
+| `os_auth_sub_uid_count` | 65536 | If /etc/subuid exists, the commands useradd and newusers (unless the user already have subordinate user IDs) allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user. See also `os_auth_sub_uid_min` and `os_auth_sub_uid_max`. | int | n |
+| `os_auth_sub_uid_max` | 600100000 | maximum number for automatic subordinate uid selection in useradd and newusers. | int | n |
+| `os_auth_sub_uid_min` | 100000 | minimum number for automatic subordinate uid selection in useradd and newusers. | int | n |
+| `os_auth_timeout` | 60 | authentication timeout in seconds, so login will exit if this time passes. | int | n |
+| `os_auth_uid_max` | 60000 | maximum number for automatic uid selection in useradd. | int | n |
+| `os_auth_uid_min` | 1000 | minimum number for automatic uid selection in useradd. | int | n |
+| `os_chfn_restrict` | '' | Indicate which fields are changeable by chfn. | str | n |
+| `os_chmod_home_folders` | true | Set to `false` to disable "chmod 700" of home folders for regular users | bool | n |
+| `os_chmod_rootuser_home_folder` | true | Set to `false` to disable "chmod 700" of root's home folder | bool | n |
+| `os_cron_enabled` | true | Set to false to disable installing and configuring cron. | bool | n |
+| `os_ctrlaltdel_disabled` | false | Set to true to disable ctrl-alt-delete key combination. | bool | n |
+| `os_desktop_enable` | false | true if this is a desktop system, ie Xorg, KDE/GNOME/Unity/etc. | bool | n |
+| `os_env_extra_user_paths` | "[]" | Specify additional paths that should be checked for binaries where access will be minimized | list | n |
+| `os_env_user_paths` | ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"] | Specify paths that should be checked for binaries where access will be minimized | list | n |
+| `os_filesystem_whitelist` | "[]" | A list of filesystems that should not be disabled | list | n |
+| `os_hardening_enabled` | true | Whether to run the hardening | bool | n |
+| `os_ignore_home_folder_users` | "[]" | Specify user accounts, whose home folders shouldn't be chmodded to 700 when "os_chmod_home_folders" is enabled. | list | n |
+| `os_ignore_users` | ["vagrant", "kitchen"] | Specify system accounts whose login should not be disabled and password not changed | list | n |
+| `os_limits_enabled` | true | Set to false to disable installing and configuring limits. | bool | n |
+| `os_login_defs_enabled` | true | Set to false to disable installing and configuring login_defs for newly created users. | bool | n |
+| `os_minimize_access_enabled` | true | Set to false to disable installing and configuring minimize_access. | bool | n |
+| `os_mnt_boot_dir_mode` | 0700 | Set default perimissions for /boot | str | n |
+| `os_mnt_boot_dump` | ext3 + ext4 = 1 / other = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_boot_enabled` | false | Set to true to configure /boot mountpoint | bool | n |
+| `os_mnt_boot_filesystem` | '' | Configure file system for fstab entry /boot. If empty, the current file system type will be used. | str | n |
+| `os_mnt_boot_options` | rw,nosuid,nodev,noexec | Configure mount options for /boot | str | n |
+| `os_mnt_boot_passno` | ext3 + ext4 = 2 / other = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_boot_src` | '' | Set mount source for /boot | str | n |
+| `os_mnt_dev_dir_mode` | 0755 | Set default perimissions for /dev | str | n |
+| `os_mnt_dev_dump` | 0 | Configure dump for fstab entry /var/tmp. | str | n |
+| `os_mnt_dev_enabled` | true | Set to false to ignore /dev mountpoint | bool | n |
+| `os_mnt_dev_filesystem` | devtmpfs | Configure file system for fstab entry /dev | str | n |
+| `os_mnt_dev_options` | rw,nosuid,noexec | Configure mount options for /dev | str | n |
+| `os_mnt_dev_passno` | 0 | Configure passno for fstab entry /var/tmp. | str | n |
+| `os_mnt_dev_shm_dir_mode` | 1777 | Set default perimissions for /dev/shm | str | n |
+| `os_mnt_dev_shm_dump` | 0 | Configure dump for fstab entry /var/tmp. | str | n |
+| `os_mnt_dev_shm_enabled` | true | Set to false to ignore /dev/shm mountpoint | bool | n |
+| `os_mnt_dev_shm_filesystem` | tmpfs | Configure file system for fstab entry /dev/shm | str | n |
+| `os_mnt_dev_shm_options` | rw,nosuid,nodev,noexec | Configure mount options for /dev/shm | str | n |
+| `os_mnt_dev_shm_passno` | 0 | Configure passno for fstab entry /var/tmp. | str | n |
+| `os_mnt_dev_shm_src` | tmpfs | Set mount source for /dev/shm | str | n |
+| `os_mnt_dev_src` | devtmpfs | Set mount source for /dev | str | n |
+| `os_mnt_home_dir_mode` | 0755 | Set default perimissions for /home | str | n |
+| `os_mnt_home_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_home_enabled` | false | Set to true to configure /home mountpoint | bool | n |
+| `os_mnt_home_filesystem` | '' | Configure file system for fstab entry /home. If empty, the current file system type will be used. | str | n |
+| `os_mnt_home_options` | rw,nosuid,nodev | Configure mount options for /home | str | n |
+| `os_mnt_home_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_home_src` | '' | Set mount source for /home. If empty, the current file system source device will be used. | str | n |
+| `os_mnt_run_dir_mode` | 0755 | Set default perimissions for /run | str | n |
+| `os_mnt_run_dump` | 0 | Configure dump for fstab entry /var/tmp. | str | n |
+| `os_mnt_run_enabled` | true | Set to false to ignore /run mountpoint | bool | n |
+| `os_mnt_run_filesystem` | tmpfs | Configure file system for fstab entry /run | str | n |
+| `os_mnt_run_options` | rw,nosuid,nodev | Configure mount options for /run | str | n |
+| `os_mnt_run_passno` | 0 | Configure passno for fstab entry /var/tmp. | str | n |
+| `os_mnt_run_src` | tmpfs | Set mount source for /run | str | n |
+| `os_mnt_tmp_dir_mode` | 1777 | Set default perimissions for /tmp | str | n |
+| `os_mnt_tmp_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_tmp_enabled` | false | Set to true to configure /tmp mountpoint | bool | n |
+| `os_mnt_tmp_filesystem` | '' | Configure file system for fstab entry /tmp. If empty, the current file system type will be used. | str | n |
+| `os_mnt_tmp_options` | rw,nosuid,nodev,noexec | Configure mount options for /tmp | str | n |
+| `os_mnt_tmp_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_tmp_src` | '' | Set mount source for /tmp. If empty, the current file system source device will be used. | str | n |
+| `os_mnt_var_dir_mode` | 0755 | Set default perimissions for /var | str | n |
+| `os_mnt_var_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_enabled` | false | Set to true to configure /var mountpoint | bool | n |
+| `os_mnt_var_filesystem` | '' | Configure file system for fstab entry /var. If empty, the current file system type will be used. | str | n |
+| `os_mnt_var_log_audit_dir_mode` | 0640 | Set default perimissions for /var/log/audit | str | n |
+| `os_mnt_var_log_audit_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_log_audit_enabled` | false | Set to true to configure /var/log/audit mountpoint | bool | n |
+| `os_mnt_var_log_audit_filesystem` | '' | Configure file system for fstab entry /var/log/audit. If empty, the current file system type will be used. | str | n |
+| `os_mnt_var_log_audit_options` | rw,nosuid,nodev,noexec | Configure mount options for /var/log/audit | str | n |
+| `os_mnt_var_log_audit_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_log_audit_src` | '' | Set mount source for /var/log/audit. If empty, the current file system source device will be used. | str | n |
+| `os_mnt_var_log_dir_mode` | 0755 | Set default perimissions for /var/log | str | n |
+| `os_mnt_var_log_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_log_enabled` | false | Set to true to configure /var/log mountpoint | bool | n |
+| `os_mnt_var_log_filesystem` | '' | Configure file system for fstab entry /var/log. If empty, the current file system type will be used. | str | n |
+| `os_mnt_var_log_options` | rw,nosuid,nodev,noexec | Configure mount options for /var/log | str | n |
+| `os_mnt_var_log_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_log_src` | '' | Set mount source for /var/log. If empty, the current file system source device will be used. | str | n |
+| `os_mnt_var_options` | rw,nosuid,nodev | Configure mount options for /var | str | n |
+| `os_mnt_var_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_src` | '' | Set mount source for /var. If empty, the current file system source device will be used. | str | n |
+| `os_mnt_var_tmp_dir_mode` | 1777 | Set default perimissions for /var/tmp | str | n |
+| `os_mnt_var_tmp_dump` | ext3/4 = 1, others = 0 | Configure dump for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_tmp_enabled` | false | Set to true to configure /var/tmp mountpoint | bool | n |
+| `os_mnt_var_tmp_filesystem` | '' | Configure file system for fstab entry /var/tmp. If empty, the current file system type will be used. | str | n |
+| `os_mnt_var_tmp_options` | rw,nosuid,nodev,noexec | Configure mount options for /var/tmp | str | n |
+| `os_mnt_var_tmp_passno` | ext3/4 = 2, others = 0 | Configure passno for fstab entry /var/tmp. If empty, the default depends on fstype. | str | n |
+| `os_mnt_var_tmp_src` | '' | Set mount source for /var/tmp. If empty, the current file system source device will be used. | str | n |
+| `os_modprobe_enabled` | true | Set to false to disable installing and configuring modprobe. | bool | n |
+| `os_netrc_enabled` | true | Configure filesystem for existence of .netrc file in homedir | bool | n |
+| `os_netrc_whitelist_user` | "[]" | Add list of user to allow creation of .netrc in users homedir | list | n |
+| `os_pam_enabled` | true | Set to false to disable installing and configuring pam. | bool | n |
+| `os_profile_enabled` | true | Set to false to disable installing and configuring profile. | bool | n |
+| `os_remove_additional_root_users` | false | When enabled and there are multiple users with UID=0, only "root" will be kept. Others will be deleted. | bool | n |
+| `os_rhosts_enabled` | true | Set to false to disable installing and configuring rhosts. | bool | n |
+| `os_rootuser_pw_ageing` | false | Set to true to enforce password age settings for root user(s) | bool | n |
+| `os_securetty_enabled` | true | Set to false to disable installing and configuring securetty. | bool | n |
+| `os_security_auto_logout` | 0 | Set timeout in seconds for logout users automatically after time. Setting this to `0` disables the timeout. | int | n |
+| `os_security_init_prompt` | true | The PROMPT option provides console users the ability to interactively boot the system and select which services to start on boot. | bool | n |
+| `os_security_init_single` | false | Single-user mode is intended as a system recovery method, providing a single user root access to the system by providing a boot option at startup. By default, no authentication is performed if single-user mode is selected. To require entry of the root password even if the system is started in single-user mode, set this to false | bool | n |
+| `os_security_kernel_enable_core_dump` | false | kernel is crashing or otherwise misbehaving and a kernel core dump is created. | bool | n |
+| `os_security_kernel_enable_module_loading` | true | true if you want to allowed to change kernel modules once the system is running (eg `modprobe`, `rmmod`). WARNING - Rebuilding initramfs is deprecated and will be removed in the next major release. For more information take a look at this issue <https://github.com/dev-sec/ansible-collection-hardening/pull/591> | bool | n |
+| `os_security_packages_clean` | true | removes packages with known issues. See section packages. | bool | n |
+| `os_security_packages_list` | ["xinetd", "inetd", "ypserv", "telnet-server", "rsh-server", "prelink"] | List of deprecated or insecure packages to remove | list | n |
+| `os_security_suid_sgid_blacklist` | "[]" | a list of paths which should have their SUID/SGID bits removed. | list | n |
+| `os_security_suid_sgid_enforce` | true | true if you want to reduce SUID/SGID bits. There is already a list of items which are searched for configured, but you can also add your own. | bool | n |
+| `os_security_suid_sgid_remove_from_unknown` | false | true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Ansible-run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`. | bool | n |
+| `os_security_suid_sgid_whitelist` | "[]" | a list of paths which should not have their SUID/SGID bits altered. | list | n |
+| `os_security_users_allow` | "[]" | list of things, that a user is allowed to do. May contain `change_user`. | list | n |
+| `os_selinux_enabled` | true | Set to false to disable installing and configuring selinux. | bool | n |
+| `os_selinux_policy` | targeted | Set the SELinux polixy. | str | n |
+| `os_selinux_state` | enforcing | Set the SELinux state, can be either disabled, permissive, or enforcing. | str | n |
+| `os_sha_crypt_max_rounds` | 640000 | Define the number of maximum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range. | int | n |
+| `os_sha_crypt_min_rounds` | 640000 | Define the number of minimum SHA rounds. With a lot of rounds brute forcing the password is more difficult. But note also that it more CPU resources will be needed to authenticate users. The values must be inside the 1000-999999999 range. | int | n |
+| `os_sysctl_enabled` | true | Set to false to disable installing and configuring sysctl. | bool | n |
+| `os_unused_filesystems` | ["cramfs", "freevxfs", "jffs2", "hfs", "hfsplus", "squashfs", "udf", "vfat", "dccp", "rds", "sctp", "tipc"] | Disable this list of unused filesystems | list | n |
+| `os_user_accounts_enabled` | true | Set to false to disable installing and configuring user_accounts. | bool | n |
+| `os_user_pw_ageing` | true | Set to false to disable password age enforcement on existing users | bool | n |
+| `os_users_without_password_ageing` | "[]" | List of users, where password ageing should not be enforced even if "os_user_pw_ageing" is enabled | list | n |
+| `os_yum_enabled` | true | Set to false to disable installing and configuring yum. | bool | n |
+| `os_yum_repo_file_whitelist` | "[]" | List of yum repository files under /etc/yum.repos.d/ which should not be altered. | list | n |
+| `proc_mnt_options` | rw,nosuid,nodev,noexec,relatime | Mount proc with hardenized options. Note that the hidepid option is set separately in vars/. | str | n |
+| `sysctl_config` | {"fs.protected_hardlinks": 1, "fs.protected_symlinks": 1, "fs.protected_fifos": 1, "fs.protected_regular": 2, "fs.suid_dumpable": 0, "kernel.core_uses_pid": 1, "kernel.kptr_restrict": 2, "kernel.kexec_load_disabled": 1, "kernel.sysrq": 0, "kernel.randomize_va_space": 2, "kernel.yama.ptrace_scope": 1, "net.ipv4.ip_forward": 0, "net.ipv6.conf.all.forwarding": 0, "net.ipv4.conf.all.rp_filter": 1, "net.ipv4.conf.default.rp_filter": 1, "net.ipv4.icmp_echo_ignore_broadcasts": 1, "net.ipv4.icmp_ignore_bogus_error_responses": 1, "net.ipv4.icmp_ratelimit": 100, "net.ipv4.icmp_ratemask": 88089, "net.ipv4.tcp_timestamps": 0, "net.ipv4.conf.all.arp_ignore": 1, "net.ipv4.conf.all.arp_announce": 2, "net.ipv4.tcp_rfc1337": 1, "net.ipv4.tcp_syncookies": 1, "net.ipv4.conf.all.shared_media": 1, "net.ipv4.conf.default.shared_media": 1, "net.ipv4.conf.all.accept_source_route": 0, "net.ipv4.conf.default.accept_source_route": 0, "net.ipv6.conf.all.accept_source_route": 0, "net.ipv6.conf.default.accept_source_route": 0, "net.ipv4.conf.all.send_redirects": 0, "net.ipv4.conf.default.send_redirects": 0, "net.ipv4.conf.all.log_martians": 1, "net.ipv4.conf.default.log_martians": 1, "net.ipv4.conf.default.accept_redirects": 0, "net.ipv4.conf.all.accept_redirects": 0, "net.ipv4.conf.all.secure_redirects": 0, "net.ipv4.conf.default.secure_redirects": 0, "net.ipv6.conf.default.accept_redirects": 0, "net.ipv6.conf.all.accept_redirects": 0, "net.ipv6.conf.all.accept_ra": 0, "net.ipv6.conf.default.accept_ra": 0, "net.ipv6.conf.default.router_solicitations": 0, "net.ipv6.conf.all.router_solicitations": 0, "net.ipv6.conf.default.accept_ra_rtr_pref": 0, "net.ipv6.conf.default.accept_ra_pinfo": 0, "net.ipv6.conf.default.accept_ra_defrtr": 0, "net.ipv6.conf.default.autoconf": 0, "net.ipv6.conf.all.autoconf": 0, "net.ipv6.conf.default.dad_transmits": 0, "net.ipv6.conf.default.max_addresses": 1, "vm.mmap_min_addr": 65536, "vm.mmap_rnd_bits": 32, "vm.mmap_rnd_compat_bits": 16} | various sysctl-settings | dict | n |
+| `sysctl_overwrite` | "{}" | To overwrite options in the `sysctl_config`-dict, overwrite them here. | dict | n |
+| `ufw_default_application_policy` | SKIP | The default application policy is skip, which means that the update --add-new command will do nothing | str | n |
+| `ufw_default_forward_policy` | DROP | set default forward policy of ufw to `DROP`. | str | n |
+| `ufw_default_input_policy` | DROP | set default input policy of ufw to `DROP`. | str | n |
+| `ufw_default_output_policy` | ACCEPT | set default output policy of ufw to `ACCEPT`. | str | n |
+| `ufw_enable_ipv6` | true | Set to `true` to apply rules to support IPv6 (no means only IPv6 on loopback accepted). | bool | n |
+| `ufw_ipt_modules` | nf_conntrack_ftp nf_nat_ftp nf_conntrack_netbios_ns | Define which netfilter modules to load | str | n |
+| `ufw_ipt_sysctl` | '' | by default it disables IPT_SYSCTL in /etc/default/ufw. If you want to overwrite /etc/sysctl.conf values using ufw - set it to your sysctl dictionary, for example `/etc/ufw/sysctl.conf`. | str | n |
+| `ufw_manage_builtins` | no | If this variable is set to 'yes', on stop and reload the built-in chains are flushed. If it is set to 'no', on stop and reload the ufw secondary chains are removed and the ufw primary chains are flushed | str | n |
+| `ufw_manage_defaults` | true | true means apply all settings with `ufw_` prefix. | bool | n |
 
 ## Dependencies
 

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -29,402 +29,62 @@ Warning: This role disables root-login on the target server! Please make sure yo
 
 ## Role Variables
 
-- `network_ipv6_enable`
-  - Default: `true`
-  - Description: `false` if IPv6 is not needed. `ssh_listen_to` must also be set to listen to IPv6 addresses (for example `[::]`).
-  - Type: bool
-  - Required: no
-- `sftp_chroot`
-  - Default: `true`
-  - Description: Set to `false` to disable chroot for sftp.
-  - Type: bool
-  - Required: no
-- `sftp_chroot_dir`
-  - Default: `/home/%u`
-  - Description: change default stp chroot location
-  - Type: str
-  - Required: no
-- `sftp_enabled`
-  - Default: `true`
-  - Description: Set to `false` to disable sftp configuration.
-  - Type: bool
-  - Required: no
-- `sftp_umask`
-  - Default: `0027`
-  - Description: Specifies the umask for sftp.
-  - Type: str
-  - Required: no
-- `ssh_allow_agent_forwarding`
-  - Default: `false`
-  - Description: Set to `false` to disable Agent Forwarding. Set to `true` to allow Agent Forwarding.
-  - Type: bool
-  - Required: no
-- `ssh_allow_groups`
-  - Default: ``
-  - Description: if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
-  - Type: str
-  - Required: no
-- `ssh_allow_tcp_forwarding`
-  - Default: `no`
-  - Description: Set to `'no'` or `false` to disable TCP Forwarding. Set to `'yes'` or`True` to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you can specify `'yes'`, `'no'`, `'all'`, `'local'`or`'remote'`.
-  - Type: str
-  - Required: no
-- `ssh_allow_users`
-  - Default: ``
-  - Description: if specified, login is allowed only for user names that match one of the patterns.
-  - Type: str
-  - Required: no
-- `ssh_authorized_keys_file`
-  - Default: ``
-  - Description: change default file that contains the public keys that can be used for user authentication
-  - Type: str
-  - Required: no
-- `ssh_authorized_principals`
-  - Default: ``
-  - Description: list of hashes containing file paths and authorized principals, see `default_cstom.yml` for all options. Only used if `ssh_authorized_principals_file` is set
-  - Type: list
-  - Required: no
-- `ssh_authorized_principals_file`
-  - Default: ``
-  - Description: specifies the file containing principals that are allowed. Only used if `ssh_trusted_user_ca_keys_file` is set.
-  - Type: str
-  - Required: no
-- `ssh_banner`
-  - Default: `false`
-  - Description: Set to `true` to print a banner on login.
-  - Type: bool
-  - Required: no
-- `ssh_banner_path`
-  - Default: `/etc/sshd/banner.txt`
-  - Description: path to the SSH banner file.
-  - Type: str
-  - Required: no
-- `ssh_challengeresponseauthentication`
-  - Default: `false`
-  - Description: Specifies whether challenge-response authentication is allowed (e.g. via PAM).
-  - Type: bool
-  - Required: no
-- `ssh_ciphers`
-  - Default: ``
-  - Description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`
-  - Type: list
-  - Required: no
-- `ssh_client_alive_count`
-  - Default: `3`
-  - Description: Defines the number of acceptable unanswered client alive messages before disconnecting clients.
-  - Type: int
-  - Required: no
-- `ssh_client_alive_interval`
-  - Default: `300`
-  - Description: specifies an interval for sending keepalive messages.
-  - Type: int
-  - Required: no
-- `ssh_client_compression`
-  - Default: `false`
-  - Description: Specifies whether the client requests compression.
-  - Type: bool
-  - Required: no
-- `ssh_client_config_file`
-  - Default: `/etc/ssh/ssh_config`
-  - Description: path of the ssh client configuration file, e.g. `/etc/ssh/ssh_config.d/custom.conf`.
-  - Type: str
-  - Required: no
-- `ssh_client_hardening`
-  - Default: `true`
-  - Description: `false` to stop harden the client.
-  - Type: bool
-  - Required: no
-- `ssh_client_host_key_algorithms`
-  - Default: ``
-  - Description: Specifies the host key algorithms that the client wants to use in order of preference. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man ssh_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version!
-  - Type: list
-  - Required: no
-- `ssh_client_password_login`
-  - Default: `false`
-  - Description: Set to `true` to allow password-based authentication with the ssh client.
-  - Type: bool
-  - Required: no
-- `ssh_client_port`
-  - Default: `22`
-  - Description: Specifies the port number to connect on the remote host.
-  - Type: str
-  - Required: no
-- `ssh_client_roaming`
-  - Default: `false`
-  - Description: enable experimental client roaming.
-  - Type: bool
-  - Required: no
-- `ssh_compression`
-  - Default: `false`
-  - Description: Specifies whether server-side compression is enabled after the user has authenticated successfully.
-  - Type: bool
-  - Required: no
-- `ssh_custom_options`
-  - Default: ``
-  - Description: Custom lines for SSH client configuration.
-  - Type: list
-  - Required: no
-- `ssh_custom_selinux_dir`
-  - Default: `/etc/selinux/local-policies`
-  - Description: directory where to store the ssh_password policy
-  - Type: str
-  - Required: no
-- `ssh_deny_groups`
-  - Default: ``
-  - Description: if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.
-  - Type: str
-  - Required: no
-- `ssh_deny_users`
-  - Default: ``
-  - Description: if specified, login is disallowed for user names that match one of the patterns.
-  - Type: str
-  - Required: no
-- `ssh_gateway_ports`
-  - Default: `false`
-  - Description: Set to `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to.
-  - Type: bool
-  - Required: no
-- `ssh_gssapi_delegation`
-  - Default: `false`
-  - Description: Set to `true` to enable GSSAPI credential forwarding.
-  - Type: bool
-  - Required: no
-- `ssh_gssapi_support`
-  - Default: `false`
-  - Description: Set to `true` to enable GSSAPI authentication (both client and server).
-  - Type: bool
-  - Required: no
-- `ssh_hardening_enabled`
-  - Default: `true`
-  - Description: Whether to run the hardening
-  - Type: bool
-  - Required: no
-- `ssh_host_certificates`
-  - Default: ``
-  - Description: Host certificates to look for when starting sshd
-  - Type: list
-  - Required: no
-- `ssh_host_key_algorithms`
-  - Default: ``
-  - Description: Host key algorithms that the server offers. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man sshd_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version
-  - Type: list
-  - Required: no
-- `ssh_host_key_files`
-  - Default: ``
-  - Description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version.
-  - Type: list
-  - Required: no
-- `ssh_host_rsa_key_size`
-  - Default: `4096`
-  - Description: Specifies the number of bits in the private host RSA key to create.
-  - Type: int
-  - Required: no
-- `ssh_kerberos_support`
-  - Default: `true`
-  - Description: Set to `true` if SSH has Kerberos support.
-  - Type: bool
-  - Required: no
-- `ssh_kex`
-  - Default: ``
-  - Description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
-  - Type: list
-  - Required: no
-- `ssh_listen_to`
-  - Default: `["0.0.0.0"]`
-  - Description: one or more ip addresses, to which ssh-server should listen to. Default is all IPv4 addresses, but should be configured to specific addresses for security reasons
-  - Type: list
-  - Required: no
-- `ssh_login_grace_time`
-  - Default: `30s`
-  - Description: specifies the time allowed for successful authentication to the SSH server.
-  - Type: str
-  - Required: no
-- `ssh_macs`
-  - Default: ``
-  - Description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`
-  - Type: list
-  - Required: no
-- `ssh_max_auth_retries`
-  - Default: `2`
-  - Description: Specifies the maximum number of authentication attempts permitted per connection.
-  - Type: int
-  - Required: no
-- `ssh_max_sessions`
-  - Default: `10`
-  - Description: Specifies the maximum number of open sessions permitted from a given connection.
-  - Type: int
-  - Required: no
-- `ssh_max_startups`
-  - Default: `10:30:60`
-  - Description: Specifies the maximum number of concurrent unauthenticated connections to the SSH daemon.
-  - Type: str
-  - Required: no
-- `ssh_pam_support`
-  - Default: `true`
-  - Description: Set to `true` if SSH has PAM support.
-  - Type: bool
-  - Required: no
-- `ssh_permit_root_login`
-  - Default: `no`
-  - Description: Disable root-login. Set to `'without-password'` or `'yes'` to enable root-login - The quotes are required!
-  - Type: str
-  - Required: no
-- `ssh_permit_tunnel`
-  - Default: `false`
-  - Description: `true` if SSH Port Tunneling is required.
-  - Type: bool
-  - Required: no
-- `ssh_print_debian_banner`
-  - Default: `false`
-  - Description: Set to `true` to print debian specific banner.
-  - Type: bool
-  - Required: no
-- `ssh_print_last_log`
-  - Default: `false`
-  - Description: Set to `false` to disable display of last login information.
-  - Type: bool
-  - Required: no
-- `ssh_print_motd`
-  - Default: `false`
-  - Description: Set to `false` to disable printing of the MOTD.
-  - Type: bool
-  - Required: no
-- `ssh_print_pam_motd`
-  - Default: `false`
-  - Description: Set to `false` to disable printing of the MOTD via pam (Debian and Ubuntu).
-  - Type: bool
-  - Required: no
-- `ssh_ps59`
-  - Default: `sandbox`
-  - Description: Specifies whether sshd separates privileges by creating an unprivileged child process to deal with incoming network traffic.
-  - Type: str
-  - Required: no
-- `ssh_remote_hosts`
-  - Default: ``
-  - Description: one or more hosts and their custom options for the ssh-client. Default is empty. See examples in `defaults/main.yml`
-  - Type: list
-  - Required: no
-- `ssh_server_accept_env_vars`
-  - Default: ``
-  - Description: Specifies what environment variables sent by the client will be copied into the session's environment, multiple environment variables may be separated by whitespace.
-  - Type: str
-  - Required: no
-- `ssh_server_config_file`
-  - Default: `/etc/ssh/sshd_config`
-  - Description: path of the ssh server configuration file, e.g. `/etc/ssh/sshd_config.d/custom.conf`.
-  - Type: str
-  - Required: no
-- `ssh_server_enabled`
-  - Default: `true`
-  - Description: Set to `false` to disable the opensshd server.
-  - Type: bool
-  - Required: no
-- `ssh_server_hardening`
-  - Default: `true`
-  - Description: `false` to stop harden the server.
-  - Type: bool
-  - Required: no
-- `ssh_server_match_address`
-  - Default: ``
-  - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
-  - Type: str
-  - Required: no
-- `ssh_server_match_group`
-  - Default: ``
-  - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
-  - Type: str
-  - Required: no
-- `ssh_server_match_local_port`
-  - Default: ``
-  - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
-  - Type: str
-  - Required: no
-- `ssh_server_match_user`
-  - Default: ``
-  - Description: Introduces a conditional block. If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, until either another Match line or the end of the file.
-  - Type: str
-  - Required: no
-- `ssh_server_password_login`
-  - Default: `false`
-  - Description: Set to `true` to allow password-based authentication to the ssh server. You probably also need to change `sshd_authenticationmethods` to include `password` if you set `ssh_server_password_login`: `true`.
-  - Type: bool
-  - Required: no
-- `ssh_server_permit_environment_vars`
-  - Default: `no`
-  - Description: `yes` to specify that ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. With openssh version 7.8 it is possible to specify a whitelist of environment variable names in addition to global 'yes' or 'no' settings.
-  - Type: str
-  - Required: no
-- `ssh_server_ports`
-  - Default: `["22"]`
-  - Description: ports on which ssh-server should listen.
-  - Type: list
-  - Required: no
-- `ssh_server_revoked_keys`
-  - Default: ``
-  - Description: a list of revoked public keys that the ssh server will always reject, useful to revoke known weak or compromised keys.
-  - Type: list
-  - Required: no
-- `ssh_trusted_user_ca_keys`
-  - Default: ``
-  - Description: set the trusted certificate authorities public keys used to sign user certificates. Only used if `ssh_trusted_user_ca_keys_file` is set.
-  - Type: list
-  - Required: no
-- `ssh_trusted_user_ca_keys_file`
-  - Default: ``
-  - Description: specifies the file containing trusted certificate authorities public keys used to sign user certificates.
-  - Type: str
-  - Required: no
-- `ssh_use_dns`
-  - Default: `false`
-  - Description: Specifies whether sshd should look up the remote host name, and to check that the resolved host name for the remote IP address maps back to the very same IP address.
-  - Type: bool
-  - Required: no
-- `ssh_use_pam`
-  - Default: `true`
-  - Description: Set to `false` to disable pam authentication.
-  - Type: bool
-  - Required: no
-- `ssh_x11_forwarding`
-  - Default: `false`
-  - Description: Set to `false` to disable X11 Forwarding. Set to `true` to allow X11 Forwarding.
-  - Type: bool
-  - Required: no
-- `sshd_authenticationmethods`
-  - Default: `publickey`
-  - Description: Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml`
-  - Type: str
-  - Required: no
-- `sshd_custom_options`
-  - Default: ``
-  - Description: Custom lines for SSH daemon configuration.
-  - Type: list
-  - Required: no
-- `sshd_log_level`
-  - Default: `VERBOSE`
-  - Description: the verbosity level that is used when logging messages from sshd.
-  - Type: str
-  - Required: no
-- `sshd_moduli_file`
-  - Default: `/etc/ssh/moduli`
-  - Description: path to the SSH moduli file.
-  - Type: str
-  - Required: no
-- `sshd_moduli_minimum`
-  - Default: `2048`
-  - Description: remove Diffie-Hellman parameters smaller than the defined size to mitigate logjam.
-  - Type: int
-  - Required: no
-- `sshd_strict_modes`
-  - Default: `true`
-  - Description: Check file modes and ownership of the user's files and home directory before accepting login.
-  - Type: bool
-  - Required: no
-- `sshd_syslog_facility`
-  - Default: `AUTH`
-  - Description: The facility code that is used when logging messages from sshd.
-  - Type: str
-  - Required: no
-
+| Variable | Default | Description | Type | Required |
+| -------- | ------- | ----------- | ---- | -------- |
+| `network_ipv6_enable` | true | `false` if IPv6 is not needed. `ssh_listen_to` must also be set to listen to IPv6 addresses (for example `[::]`). | bool | n |
+| `sftp_chroot` | true | Set to `false` to disable chroot for sftp. | bool | n |
+| `sftp_chroot_dir` | /home/%u | change default stp chroot location | str | n |
+| `sftp_enabled` | true | Set to `false` to disable sftp configuration. | bool | n |
+| `sftp_umask` | 0027 | Specifies the umask for sftp. | str | n |
+| `ssh_allow_agent_forwarding` | false | Set to `false` to disable Agent Forwarding. Set to `true` to allow Agent Forwarding. | bool | n |
+| `ssh_allow_tcp_forwarding` | no | Set to `'no'` or `false` to disable TCP Forwarding. Set to `'yes'` or`True` to allow TCP Forwarding. If you are using OpenSSH >= 6.2 version, you can specify `'yes'`, `'no'`, `'all'`, `'local'`or`'remote'`. | str | n |
+| `ssh_banner` | false | Set to `true` to print a banner on login. | bool | n |
+| `ssh_banner_path` | /etc/sshd/banner.txt | path to the SSH banner file. | str | n |
+| `ssh_challengeresponseauthentication` | false | Specifies whether challenge-response authentication is allowed (e.g. via PAM). | bool | n |
+| `ssh_client_alive_count` | 3 | Defines the number of acceptable unanswered client alive messages before disconnecting clients. | int | n |
+| `ssh_client_alive_interval` | 300 | specifies an interval for sending keepalive messages. | int | n |
+| `ssh_client_compression` | false | Specifies whether the client requests compression. | bool | n |
+| `ssh_client_config_file` | /etc/ssh/ssh_config | path of the ssh client configuration file, e.g. `/etc/ssh/ssh_config.d/custom.conf`. | str | n |
+| `ssh_client_hardening` | true | `false` to stop harden the client. | bool | n |
+| `ssh_client_password_login` | false | Set to `true` to allow password-based authentication with the ssh client. | bool | n |
+| `ssh_client_port` | 22 | Specifies the port number to connect on the remote host. | str | n |
+| `ssh_client_roaming` | false | enable experimental client roaming. | bool | n |
+| `ssh_compression` | false | Specifies whether server-side compression is enabled after the user has authenticated successfully. | bool | n |
+| `ssh_custom_selinux_dir` | /etc/selinux/local-policies | directory where to store the ssh_password policy | str | n |
+| `ssh_gateway_ports` | false | Set to `false` to disable binding forwarded ports to non-loopback addresses. Set to `true` to force binding on wildcard address. Set to `clientspecified` to allow the client to specify which address to bind to. | bool | n |
+| `ssh_gssapi_delegation` | false | Set to `true` to enable GSSAPI credential forwarding. | bool | n |
+| `ssh_gssapi_support` | false | Set to `true` to enable GSSAPI authentication (both client and server). | bool | n |
+| `ssh_hardening_enabled` | true | Whether to run the hardening | bool | n |
+| `ssh_host_rsa_key_size` | 4096 | Specifies the number of bits in the private host RSA key to create. | int | n |
+| `ssh_kerberos_support` | true | Set to `true` if SSH has Kerberos support. | bool | n |
+| `ssh_listen_to` | ["0.0.0.0"] | one or more ip addresses, to which ssh-server should listen to. Default is all IPv4 addresses, but should be configured to specific addresses for security reasons | list | n |
+| `ssh_login_grace_time` | 30s | specifies the time allowed for successful authentication to the SSH server. | str | n |
+| `ssh_max_auth_retries` | 2 | Specifies the maximum number of authentication attempts permitted per connection. | int | n |
+| `ssh_max_sessions` | 10 | Specifies the maximum number of open sessions permitted from a given connection. | int | n |
+| `ssh_max_startups` | 10:30:60 | Specifies the maximum number of concurrent unauthenticated connections to the SSH daemon. | str | n |
+| `ssh_pam_support` | true | Set to `true` if SSH has PAM support. | bool | n |
+| `ssh_permit_root_login` | no | Disable root-login. Set to `'without-password'` or `'yes'` to enable root-login - The quotes are required! | str | n |
+| `ssh_permit_tunnel` | false | `true` if SSH Port Tunneling is required. | bool | n |
+| `ssh_print_debian_banner` | false | Set to `true` to print debian specific banner. | bool | n |
+| `ssh_print_last_log` | false | Set to `false` to disable display of last login information. | bool | n |
+| `ssh_print_motd` | false | Set to `false` to disable printing of the MOTD. | bool | n |
+| `ssh_print_pam_motd` | false | Set to `false` to disable printing of the MOTD via pam (Debian and Ubuntu). | bool | n |
+| `ssh_ps59` | sandbox | Specifies whether sshd separates privileges by creating an unprivileged child process to deal with incoming network traffic. | str | n |
+| `ssh_server_config_file` | /etc/ssh/sshd_config | path of the ssh server configuration file, e.g. `/etc/ssh/sshd_config.d/custom.conf`. | str | n |
+| `ssh_server_enabled` | true | Set to `false` to disable the opensshd server. | bool | n |
+| `ssh_server_hardening` | true | `false` to stop harden the server. | bool | n |
+| `ssh_server_password_login` | false | Set to `true` to allow password-based authentication to the ssh server. You probably also need to change `sshd_authenticationmethods` to include `password` if you set `ssh_server_password_login`: `true`. | bool | n |
+| `ssh_server_permit_environment_vars` | no | `yes` to specify that ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. With openssh version 7.8 it is possible to specify a whitelist of environment variable names in addition to global 'yes' or 'no' settings. | str | n |
+| `ssh_server_ports` | ["22"] | ports on which ssh-server should listen. | list | n |
+| `ssh_use_dns` | false | Specifies whether sshd should look up the remote host name, and to check that the resolved host name for the remote IP address maps back to the very same IP address. | bool | n |
+| `ssh_use_pam` | true | Set to `false` to disable pam authentication. | bool | n |
+| `ssh_x11_forwarding` | false | Set to `false` to disable X11 Forwarding. Set to `true` to allow X11 Forwarding. | bool | n |
+| `sshd_authenticationmethods` | publickey | Specifies the authentication methods that must be successfully completed for a user to be granted access. Make sure to set all required variables for your selected authentication method. Defaults found in `defaults/main.yml` | str | n |
+| `sshd_log_level` | VERBOSE | the verbosity level that is used when logging messages from sshd. | str | n |
+| `sshd_moduli_file` | /etc/ssh/moduli | path to the SSH moduli file. | str | n |
+| `sshd_moduli_minimum` | 2048 | remove Diffie-Hellman parameters smaller than the defined size to mitigate logjam. | int | n |
+| `sshd_strict_modes` | true | Check file modes and ownership of the user's files and home directory before accepting login. | bool | n |
+| `sshd_syslog_facility` | AUTH | The facility code that is used when logging messages from sshd. | str | n |
 ## Dependencies
 
 None.


### PR DESCRIPTION
In my opinion the current documentation for role variables is a bit confusing to read, you might like the change to the table overview.