### PR TITLE
Gather facts when os_hardening role is executed with tags

### DIFF
--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -1,4 +1,10 @@
 ---
+- name: Gather facts, if not present
+  ansible.builtin.setup:
+  when: ansible_facts == {}
+  tags:
+    - always
+
 - name: Fetch OS dependent variables
   ansible.builtin.include_vars:
     file: "{{ item }}"

--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -1,7 +1,7 @@
 ---
 - name: Gather facts, if not present
   ansible.builtin.setup:
-  when: ansible_facts == {}
+  when: not ansible_facts
   tags:
     - always
 


### PR DESCRIPTION
Our os_hardening role is supposed to be usable with tags. Since Ansible 2.8 facts are not automatically gathered, if the paybook is called with tags. By using a separate step to gather facts in our role we make the role usable with tags again.