### PR TITLE
match RedHat vars for Rocky 9

### DIFF
--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -8,6 +8,8 @@
         - "{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml"
         - "{{ ansible_facts.distribution }}.yml"
         - "{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}_{{ ansible_facts.ansible_distribution_major_version }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}.yml"
         - "{{ ansible_facts.os_family }}.yml"
       skip: true
   tags: always

--- a/roles/os_hardening/tasks/hardening.yml
+++ b/roles/os_hardening/tasks/hardening.yml
@@ -14,6 +14,8 @@
         - "{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml"
         - "{{ ansible_facts.distribution }}.yml"
         - "{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}_{{ ansible_facts.ansible_distribution_major_version }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}.yml"
         - "{{ ansible_facts.os_family }}.yml"
       skip: true
   tags: always

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -8,6 +8,8 @@
         - "{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version | default() }}.yml"
         - "{{ ansible_facts.distribution }}.yml"
         - "{{ ansible_facts.os_family }}_{{ ansible_facts.distribution_major_version | default() }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}_{{ ansible_facts.ansible_distribution_major_version }}.yml"
+        - "{{ ansible_facts.ansible_distribution_file_variety }}.yml"
         - "{{ ansible_facts.os_family }}.yml"
       skip: true
   tags: always


### PR DESCRIPTION
These changes were made to match the Rocky 9 distro with RedHat.yml or RedHat_9.yml vars

Rocky 9 ansible_facts:

```json
    "ansible_facts": {

        "ansible_distribution": "Rocky",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "Blue Onyx",
        "ansible_distribution_version": "9.2",
```