### PR TITLE
Add tags for cron.yml

### DIFF
--- a/roles/os_hardening/tasks/cron.yml
+++ b/roles/os_hardening/tasks/cron.yml
@@ -18,6 +18,7 @@
       - crontab
     file_type: any
   register: cron_directories
+  tags: cron
 
 - name: Ensure permissions on cron files and directories are configured
   ansible.builtin.file:
@@ -26,3 +27,4 @@
     group: root
     mode: og-rwx
   with_items: "{{ cron_directories.files }}"
+  tags: cron


### PR DESCRIPTION
Add tags in cron.yml

As the code in tasks/hardening.yml, the "Import tasks for cron" task import tasks from cron.yml based on tags: cron.
But the twos tasks in cron.yml missed tags: cron field.
![image](https://github.com/dev-sec/ansible-collection-hardening/assets/19709103/9fc81286-b2bb-4a78-8d34-7046066ed8dc)
