### PR TITLE
Remove Docker containers on self-hosted runner after tests

### DIFF
--- a/molecule/os_hardening_vm/verify.yml
+++ b/molecule/os_hardening_vm/verify.yml
@@ -39,7 +39,7 @@
 
     - name: Execute cinc-auditor tests
       ansible.builtin.command: >
-        docker run
+        docker run --rm
         --volume {{ molecule_ephemeral_directory }}:{{ molecule_ephemeral_directory }}
         docker.io/cincproject/auditor exec
         --ssh-config-file={{ molecule_ephemeral_directory }}/ssh-config

--- a/molecule/ssh_hardening_bsd/verify.yml
+++ b/molecule/ssh_hardening_bsd/verify.yml
@@ -34,7 +34,7 @@
 
     - name: Execute cinc-auditor tests
       ansible.builtin.command: >
-        docker run
+        docker run --rm
         --volume {{ molecule_ephemeral_directory }}:{{ molecule_ephemeral_directory }}
         --volume ./waivers_{{ lookup('env', 'MOLECULE_DISTRO') }}.yaml:/waivers.yaml
         docker.io/cincproject/auditor exec


### PR DESCRIPTION
Our runner got a bit messy and had no more anonymous volumes after a few months. This fixes the root of the problem and removes all associated metadata after running the tests.