### PR TITLE
ci: define permissions for enforce-labels workflow 

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -4,6 +4,11 @@ name: "Enforce PR labels"
 on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
+
+permissions:
+  contents: read # to read configuration file
+  pull-requests: write # to label PRs
+
 jobs:
   enforce-label:
     if: github.repository == 'dev-sec/ansible-collection-hardening'


### PR DESCRIPTION
Explicitely stating required permissions is considered best practice.
This case was detected by Poutine, see
https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/default_permissions_on_risky_events.md.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)