### PR TITLE
feat: add fedora 40 to test matrix

### DIFF
--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -43,6 +43,7 @@ jobs:
           - rocky9
           - fedora38
           - fedora39
+          - fedora40
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -43,6 +43,7 @@ jobs:
           - generic/rocky9
           - fedora/38-cloud-base
           - fedora/39-cloud-base
+          - fedora/40-beta-cloud-base
           - generic/ubuntu1804
           - generic/ubuntu2004
           - generic/ubuntu2204

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -43,6 +43,7 @@ jobs:
           - rocky9
           - fedora38
           - fedora39
+          - fedora40
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -43,6 +43,7 @@ jobs:
           - rocky9
           - fedora38
           - fedora39
+          - fedora40
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204


### PR DESCRIPTION
Depends on:
- https://github.com/dev-sec/docker-ansible/pull/49
- https://dl.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/ deployment to https://app.vagrantup.com/fedora (for some reason still shows only shows beta deployed)
- probably needs some tweaks