### PR TITLE
ssh: explicitly enable or disable the service at boot

### DIFF
--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -6,8 +6,11 @@ network_ipv6_enable: true # sshd + ssh
 ssh_client_config_file: /etc/ssh/ssh_config # ssh
 ssh_server_config_file: /etc/ssh/sshd_config # sshd
 
-# true if sshd should be started and enabled
+# true if sshd should be started
 ssh_server_enabled: true # sshd
+
+# true if sshd should be enabled at boot
+ssh_server_service_enabled: true # sshd
 
 # true if DNS resolutions are needed, look up the remote host name,
 # defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -135,3 +135,8 @@
   when:
     - sshd_disable_crypto_policy | bool
     - ('crypto-policies' in ansible_facts.packages)
+
+- name: Enable or disable sshd service
+  ansible.builtin.service:
+    name: "{{ sshd_service_name }}"
+    enabled: "{{ ssh_server_service_enabled }}"


### PR DESCRIPTION
Hello,

This PR aims to explicitly allow someone to enable or disable the sshd service at boot. They are 2 main reasons/use cases:

1. We should not trust the distro/package manager default state for the service. We should explicitly set the "enabled" setting at true or false if it's what we want to
2. Even given the usual need of a always on sshd for a Ansible user, Ansible can also be used with a local connexion. For example, I'm planning on using this role to configure sshd on a laptop, I don't need the service up and running at each boot but I would still like to benefit from the hardened settings when I'm starting it to transfer some files or to work on my laptop from a remote computer.

Hopefully my variable naming is not too confusing, maybe we could rename the `ssh_server_enabled` var but this would create a braking change :/

S.