### PR TITLE
Pin GitHub Actions using Frizbee

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Lint Ansible Playbook
-        uses: ansible/ansible-lint@v24
+        uses: ansible/ansible-lint@2d9f1ed1e6d08e1f6a18e50f789ab1580220c7db # v24

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -11,30 +11,30 @@ jobs:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       # deploy the collection first, because if it fails, we don't want
       # to update the galaxy.yml
       - name: Deploy the collection
-        uses: artis3n/ansible_galaxy_collection@v2
+        uses: artis3n/ansible_galaxy_collection@3368f56529a2ef47ef0ac1ecfcda039f90d0174a # v2
         with:
           api_key: ${{ secrets.GALAXY_API_KEY }}
           galaxy_version: ${{ github.event.release.tag_name }}
 
       # checkout master instead of the release-tag so we can push the galaxy.yml
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           ref: master
 
       - name: update galaxy.yml with new version
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@b1e0d9ee8c194d95db944d60f5b4821413a039b4 # v1
         with:
           files: 'galaxy.yml'
         env:
           version: "${{ github.event.release.tag_name }}"
 
       - name: push galaxy.yml
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'master'

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -52,13 +52,13 @@ jobs:
           # - fedora  # geerlingguy.mysql does not support fedora
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -51,13 +51,13 @@ jobs:
           # - fedora  # no support from geerlingguy role
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -52,13 +52,13 @@ jobs:
           - arch
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -51,7 +51,7 @@ jobs:
           - generic/arch
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true

--- a/.github/workflows/prettier-md.yml
+++ b/.github/workflows/prettier-md.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Prettify code
-        uses: creyD/prettier_action@v4.3
+        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3
         with:
           prettier_options: --write {**/*,*}.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
           ref: master
@@ -26,12 +26,12 @@ jobs:
 
       - name: calculate next version
         id: version
-        uses: patrickjahns/version-drafter-action@v1
+        uses: patrickjahns/version-drafter-action@fda4b8e4017bee5dd5794f255a4d484e8e647561 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate changelog
-        uses: charmixer/auto-changelog-action@v1
+        uses: charmixer/auto-changelog-action@dc40535ee3847b9aa975481644d187761d2ebc53 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           future_release: ${{ steps.version.outputs.next-version }}
@@ -42,7 +42,7 @@ jobs:
           issue_line_labels: mysql_hardening,os_hardening,ssh_hardening,nginx_hardening
 
       - name: push changelog
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'master'
@@ -58,18 +58,18 @@ jobs:
 
       - name: Read CHANGELOG.md
         id: package
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1
         with:
           path: ./CHANGELOGRELEASE.md
 
       - name: Delete old drafts
-        uses: hugo19941994/delete-draft-releases@v1.0.1
+        uses: hugo19941994/delete-draft-releases@1bdca1ea7ffb25ae7f468a7bdb40056dae98175e # v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release draft
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/roles-readme.yml
+++ b/.github/workflows/roles-readme.yml
@@ -26,10 +26,10 @@ jobs:
           - ssh_hardening
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Push README
         if: github.event_name != 'pull_request'
-        uses: github-actions-x/commit@v2.9
+        uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'update ${{ matrix.roles }} readme'

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -52,13 +52,13 @@ jobs:
           # - opensuse_tumbleweed  # needs fix - opensuse has different file location for conf and pam (/usr/etc/ssh/?, /usr/lib/pam.d/?)
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 

--- a/.github/workflows/ssh_hardening_bsd.yml
+++ b/.github/workflows/ssh_hardening_bsd.yml
@@ -42,7 +42,7 @@ jobs:
           - freebsd14
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -52,13 +52,13 @@ jobs:
           # - opensuse_tumbleweed  # needs fix - opensuse has different file location for conf and pam (/usr/etc/ssh/?, /usr/lib/pam.d/?)
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           path: ansible_collections/devsec/hardening
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           python-version: 3.12
 


### PR DESCRIPTION
Hey, 👋 

The following PR pins actions to their commit hash.

Pinning images and actions to their commit hash ensures that the same version of the image or action is used every time the workflow runs. This is important for reproducibility and security and it is a [security practice recommended by GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

I did this using the [frizbee](https://github.com/stacklok/frizbee) CLI, but if you liked it and also want to keep this consistent there's a [frizbee-action](https://github.com/stacklok/frizbee-action) which you can use to automate this.

Thanks!