### PR TITLE
Use best-practice preset for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":gitSignOff"
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
Switch to best-practice preset for Renovate. This pins GitHub Actions by digest. THere are also other options enabled which should not bother us. 