### PR TITLE
Update Debian compatibility

### DIFF
--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -40,9 +40,9 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
           - debian10
           - debian11
           - debian12

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -43,7 +43,6 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-          - debian10
           - debian11
           - debian12
           # - amazon  # geerlingguy.mysql does not support fedora

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -39,9 +39,9 @@ jobs:
           - centosstream9
           - rocky8
           - rocky9
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
           - debian10
           - debian11
           - debian12

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -42,7 +42,6 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-          - debian10
           - debian11
           - debian12
           - amazon2023

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -44,7 +44,6 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-          - debian10
           - debian11
           - debian12
           - amazon2023

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -41,9 +41,9 @@ jobs:
           - rocky9
           - fedora39
           - fedora40
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
           - debian10
           - debian11
           - debian12

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -41,9 +41,9 @@ jobs:
           - generic/rocky9
           - fedora/39-cloud-base
           - fedora/40-cloud-base
-          - generic/ubuntu1804
           - generic/ubuntu2004
           - generic/ubuntu2204
+          - generic/ubuntu2404
           - generic/debian10
           - generic/debian11
           - generic/debian12

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -43,7 +43,7 @@ jobs:
           - fedora/40-cloud-base
           - generic/ubuntu2004
           - generic/ubuntu2204
-          - generic/ubuntu2404
+          - alvistack/ubuntu-24.04
           - generic/debian10
           - generic/debian11
           - generic/debian12

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -44,7 +44,6 @@ jobs:
           - generic/ubuntu2004
           - generic/ubuntu2204
           - alvistack/ubuntu-24.04
-          - generic/debian10
           - generic/debian11
           - generic/debian12
           - generic/opensuse15

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -44,7 +44,6 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-          - debian10
           - debian11
           - debian12
           - amazon2023

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -41,9 +41,9 @@ jobs:
           - rocky9
           - fedora39
           - fedora40
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
           - debian10
           - debian11
           - debian12

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -44,7 +44,6 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-          - debian10
           - debian11
           - debian12
           - amazon2023

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -41,9 +41,9 @@ jobs:
           - rocky9
           - fedora39
           - fedora40
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
           - debian10
           - debian11
           - debian12

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This collection provides battle tested hardening for:
   - CentOS 9
   - Rocky Linux 8/9
   - Debian 10/11/12
-  - Ubuntu 18.04/20.04/22.04
+  - Ubuntu 20.04/22.04/24.04
   - Amazon Linux (some roles supported)
   - Arch Linux (some roles supported)
   - Fedora 39/40 (some roles supported)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This collection provides battle tested hardening for:
 - Linux operating systems:
   - CentOS 9
   - Rocky Linux 8/9
-  - Debian 10/11/12
+  - Debian 11/12
   - Ubuntu 20.04/22.04/24.04
   - Amazon Linux (some roles supported)
   - Arch Linux (some roles supported)

--- a/molecule/mysql_hardening/prepare.yml
+++ b/molecule/mysql_hardening/prepare.yml
@@ -26,13 +26,6 @@
       when:
         - ansible_os_family == 'Suse'
 
-    - name: Use Python 2 on Debian 10
-      ansible.builtin.set_fact:
-        ansible_python_interpreter: /usr/bin/python
-      when:
-        - ansible_distribution == 'Debian'
-        - ansible_distribution_major_version|int == 10
-
     - name: Run the equivalent of "apt-get update && apt-get upgrade"
       ansible.builtin.apt:
         upgrade: safe

--- a/molecule/ssh_hardening/prepare.yml
+++ b/molecule/ssh_hardening/prepare.yml
@@ -62,12 +62,6 @@
         update_cache: true
       when: ansible_facts.os_family == 'Archlinux'
 
-    - name: Created needed directory
-      ansible.builtin.file:
-        path: /var/run/sshd
-        state: directory
-        mode: "0755"
-
     - name: Create ssh host keys # noqa ignore-errors
       ansible.builtin.command: ssh-keygen -A
       when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7')

--- a/molecule/ssh_hardening_bsd/prepare.yml
+++ b/molecule/ssh_hardening_bsd/prepare.yml
@@ -18,12 +18,6 @@
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
   tasks:
-    - name: Created needed directory
-      ansible.builtin.file:
-        path: /var/run/sshd
-        state: directory
-        mode: "0755"
-
     - name: Create ssh host keys # noqa ignore-errors
       ansible.builtin.command: ssh-keygen -A
       when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7')

--- a/molecule/ssh_hardening_custom_tests/prepare.yml
+++ b/molecule/ssh_hardening_custom_tests/prepare.yml
@@ -62,12 +62,6 @@
         update_cache: true
       when: ansible_facts.os_family == 'Archlinux'
 
-    - name: Created needed directory
-      ansible.builtin.file:
-        path: /var/run/sshd
-        state: directory
-        mode: "0755"
-
     - name: Create ssh host keys # noqa ignore-errors
       ansible.builtin.command: ssh-keygen -A
       when: not ((ansible_facts.os_family in ['Oracle Linux', 'RedHat']) and ansible_facts.distribution_major_version < '7')

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
     - name: Debian
       versions:
         - bullseye
-        - buster
+        - bookworm
     - name: Amazon
     - name: opensuse
   galaxy_tags:

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -12,9 +12,9 @@ galaxy_info:
         - "9"
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
+        - noble
     - name: Debian
       versions:
         - bullseye

--- a/roles/nginx_hardening/meta/main.yml
+++ b/roles/nginx_hardening/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
         - noble
     - name: Debian
       versions:
-        - buster
+        - bookworm
         - bullseye
     - name: Amazon
   galaxy_tags:

--- a/roles/nginx_hardening/meta/main.yml
+++ b/roles/nginx_hardening/meta/main.yml
@@ -12,9 +12,9 @@ galaxy_info:
         - "9"
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
+        - noble
     - name: Debian
       versions:
         - buster

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -12,9 +12,9 @@ galaxy_info:
         - "9"
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
+        - noble
     - name: Debian
       versions:
         - buster

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
         - noble
     - name: Debian
       versions:
-        - buster
+        - bookworm
         - bullseye
     - name: Amazon
     - name: Fedora

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -12,9 +12,9 @@ galaxy_info:
         - "9"
     - name: Ubuntu
       versions:
-        - bionic
         - focal
         - jammy
+        - noble
     - name: Debian
       versions:
         - buster

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
         - noble
     - name: Debian
       versions:
-        - buster
+        - bookworm
         - bullseye
     - name: Amazon
     - name: Fedora

--- a/roles/ssh_hardening/tasks/disable-systemd-socket.yml
+++ b/roles/ssh_hardening/tasks/disable-systemd-socket.yml
@@ -10,3 +10,4 @@
     state: stopped
     enabled: false
     masked: true
+    daemon_reload: true

--- a/roles/ssh_hardening/tasks/disable-systemd-socket.yml
+++ b/roles/ssh_hardening/tasks/disable-systemd-socket.yml
@@ -1,8 +1,11 @@
 ---
 - name: Remove ssh service systemd-socket file
   ansible.builtin.file:
-    path: /etc/systemd/system/ssh.service.d/00-socket.conf
+    path: "{{ item }}"
     state: absent
+  loop:
+    - /etc/systemd/system/ssh.service.d/00-socket.conf
+    - /etc/systemd/system/ssh.service.requires/ssh.socket
 
 - name: Disable systemd-socket activation
   ansible.builtin.systemd:
@@ -10,4 +13,3 @@
     state: stopped
     enabled: false
     masked: true
-    daemon_reload: true

--- a/roles/ssh_hardening/tasks/disable-systemd-socket.yml
+++ b/roles/ssh_hardening/tasks/disable-systemd-socket.yml
@@ -6,6 +6,7 @@
   loop:
     - /etc/systemd/system/ssh.service.d/00-socket.conf
     - /etc/systemd/system/ssh.service.requires/ssh.socket
+    - /etc/systemd/system/sockets.target.wants/ssh.socket
 
 - name: Disable systemd-socket activation
   ansible.builtin.systemd:

--- a/roles/ssh_hardening/tasks/install.yml
+++ b/roles/ssh_hardening/tasks/install.yml
@@ -17,6 +17,18 @@
     - (ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version is version('22.04', '>=')) or
       (ansible_facts.os_family == 'Debian' and ansible_facts.distribution_major_version is version('12', '>='))
 
+- name: Ensure privilege separation directory exists
+  ansible.builtin.file:
+    path: /run/sshd
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when:
+    - ssh_server_hardening | bool
+    - ssh_server_enabled | bool
+    - ansible_facts.os_family == 'Debian'
+
 - name: Enable or disable sshd service
   ansible.builtin.service:
     name: "{{ sshd_service_name }}"


### PR DESCRIPTION
Newer versions of Debian/Ubuntu will not create the `/run/ssh` directory because of socket activation. We have to create it ourselves. This is not a problem in RPM based distros, since they create it as part of the RPM.

Also because of socket activation there is a systemd dependency of `ssh.service` to `ssh.socket`. This dependency can be removed with systemd commands but the process is tedious and deleting the relevant files in `/etc/systemd` achieves the same result much simpler.