### PR TITLE
Provide granular noop for ssh configuration

### DIFF
--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -138,14 +138,9 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Specifies whether challenge-response authentication is allowed (e.g. via PAM).
   - Type: bool
   - Required: no
-- `ssh_ciphers_config`
-  - Default: `true`
-  - Description: Whether or not configuring the ciphers of the server.
-  - Type: bool
-  - Required: no
 - `ssh_ciphers`
-  - Default: ``
-  - Description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`
+  - Default: undefined
+  - Description: Set a list of ciphers to override the one defined in `vars/main.yml`, or set it to false to skip this configuration.
   - Type: list
   - Required: no
 - `ssh_client_alive_count`
@@ -243,19 +238,14 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Host certificates to look for when starting sshd
   - Type: list
   - Required: no
-- `ssh_host_key_config`
-  - Default: `true`
-  - Description: Whether or not configuring the host keys of that the server offers.
-  - Type: bool
-  - Required: no
 - `ssh_host_key_algorithms`
   - Default: ``
   - Description: Host key algorithms that the server offers. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man sshd_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version
   - Type: list
   - Required: no
 - `ssh_host_key_files`
-  - Default: ``
-  - Description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version.
+  - Default: undefined
+  - Description: Host keys for sshd. If undefined ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key', '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the installed sshd version, and a new `ssh_host_rsa_key` may be generated according to `ssh_host_rsa_key_size`.  Set it to false to skip this configuration.
   - Type: list
   - Required: no
 - `ssh_host_rsa_key_size`
@@ -268,14 +258,9 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Set to `true` if SSH has Kerberos support.
   - Type: bool
   - Required: no
-- `ssh_kex_config`
-  - Default: `true`
-  - Description: Whether or not configuring the kexs of the server.
-  - Type: bool
-  - Required: no
 - `ssh_kex`
-  - Default: ``
-  - Description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
+  - Default: undefined
+  - Description: Set a list of Key Exchange Algorithms to override the one defined in `vars/main.yml`, or set it to false to skip this configuration.
   - Type: list
   - Required: no
 - `ssh_listen_to`
@@ -288,14 +273,9 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: specifies the time allowed for successful authentication to the SSH server.
   - Type: str
   - Required: no
-- `ssh_macs_config`
-  - Default: `true`
-  - Description: Whether or not configuring the macs of the server.
-  - Type: bool
-  - Required: no
 - `ssh_macs`
-  - Default: ``
-  - Description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`
+  - Default: undefined
+  - Description: Set a list of macs to override the one defined in `vars/main.yml`, or set it to false to skip this configuration.
   - Type: list
   - Required: no
 - `ssh_max_auth_retries`

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -138,6 +138,11 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Specifies whether challenge-response authentication is allowed (e.g. via PAM).
   - Type: bool
   - Required: no
+- `ssh_ciphers_config`
+  - Default: `true`
+  - Description: Whether or not configuring the ciphers of the server.
+  - Type: bool
+  - Required: no
 - `ssh_ciphers`
   - Default: ``
   - Description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`
@@ -238,6 +243,11 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Host certificates to look for when starting sshd
   - Type: list
   - Required: no
+- `ssh_host_key_config`
+  - Default: `true`
+  - Description: Whether or not configuring the host keys of that the server offers.
+  - Type: bool
+  - Required: no
 - `ssh_host_key_algorithms`
   - Default: ``
   - Description: Host key algorithms that the server offers. If empty the default list will be used. Otherwise overrides the setting with specified list of algorithms. Check `man sshd_config`, `ssh -Q HostKeyAlgorithms` or other sources for supported algorithms - make sure you check the correct version
@@ -258,6 +268,11 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Description: Set to `true` if SSH has Kerberos support.
   - Type: bool
   - Required: no
+- `ssh_kex_config`
+  - Default: `true`
+  - Description: Whether or not configuring the kexs of the server.
+  - Type: bool
+  - Required: no
 - `ssh_kex`
   - Default: ``
   - Description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
@@ -272,6 +287,11 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - Default: `30s`
   - Description: specifies the time allowed for successful authentication to the SSH server.
   - Type: str
+  - Required: no
+- `ssh_macs_config`
+  - Default: `true`
+  - Description: Whether or not configuring the macs of the server.
+  - Type: bool
   - Required: no
 - `ssh_macs`
   - Default: ``

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -40,12 +40,6 @@ ssh_client_port: "22" # ssh
 # Default is empty, but should be configured for security reasons!
 ssh_listen_to: [0.0.0.0] # sshd
 
-# Whether or not configuring and generating the host keys files
-ssh_host_key_config: true # sshd
-
-# Host keys to look for when starting sshd.
-ssh_host_key_files: [] # sshd
-
 # Host RSA key size in bits
 ssh_host_rsa_key_size: 4096 # sshd
 
@@ -209,13 +203,6 @@ ssh_max_startups: 10:30:60 # sshd
 
 ssh_ps59: sandbox
 
-# Whether or not configuring the macs, cihers and kex algorithms
-ssh_macs_config: true      # sshd
-ssh_ciphers_config: true
-ssh_kex_config: true
-ssh_macs: []
-ssh_ciphers: []
-ssh_kex: []
 # directory where to store ssh_password policy
 ssh_custom_selinux_dir: /etc/selinux/local-policies
 

--- a/roles/ssh_hardening/defaults/main.yml
+++ b/roles/ssh_hardening/defaults/main.yml
@@ -40,6 +40,9 @@ ssh_client_port: "22" # ssh
 # Default is empty, but should be configured for security reasons!
 ssh_listen_to: [0.0.0.0] # sshd
 
+# Whether or not configuring and generating the host keys files
+ssh_host_key_config: true # sshd
+
 # Host keys to look for when starting sshd.
 ssh_host_key_files: [] # sshd
 
@@ -206,6 +209,10 @@ ssh_max_startups: 10:30:60 # sshd
 
 ssh_ps59: sandbox
 
+# Whether or not configuring the macs, cihers and kex algorithms
+ssh_macs_config: true      # sshd
+ssh_ciphers_config: true
+ssh_kex_config: true
 ssh_macs: []
 ssh_ciphers: []
 ssh_kex: []

--- a/roles/ssh_hardening/meta/argument_specs.yml
+++ b/roles/ssh_hardening/meta/argument_specs.yml
@@ -28,12 +28,8 @@ argument_specs:
         description: one or more ip addresses, to which ssh-server should listen to.
           Default is all IPv4 addresses, but should be configured to specific addresses
           for security reasons
-      ssh_host_key_config:
-        default: true
-        type: bool
-        description: Whether or not configuring the host keys of that the server offers.
       ssh_host_key_files:
-        default: []
+        default: undefined
         type: list
         description: Host keys for sshd. If empty ['/etc/ssh/ssh_host_rsa_key', '/etc/ssh/ssh_host_ecdsa_key',
           '/etc/ssh/ssh_host_ed25519_key'] will be used, as far as supported by the
@@ -321,28 +317,16 @@ argument_specs:
         default: 10:30:60
         description: Specifies the maximum number of concurrent unauthenticated connections
           to the SSH daemon.
-      ssh_macs_config:
-        default: true
-        description: Whether or not configuring the macs of the server.
-        type: bool
       ssh_macs:
-        default: []
+        default: undefined
         type: list
         description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`
-      ssh_kex_config:
-        default: true
-        description: Whether or not configuring the kexs of the server.
-        type: bool
       ssh_kex:
-        default: []
+        default: undefined
         type: list
         description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
-      ssh_ciphers_config:
-        default: true
-        description: Whether or not configuring the ciphers of the server.
-        type: bool
       ssh_ciphers:
-        default: []
+        default: undefined
         type: list
         description: Change this list to overwrite ciphers. Defaults found in `defaults/main.yml`
       ssh_custom_options:

--- a/roles/ssh_hardening/meta/argument_specs.yml
+++ b/roles/ssh_hardening/meta/argument_specs.yml
@@ -28,6 +28,10 @@ argument_specs:
         description: one or more ip addresses, to which ssh-server should listen to.
           Default is all IPv4 addresses, but should be configured to specific addresses
           for security reasons
+      ssh_host_key_config:
+        default: true
+        type: bool
+        description: Whether or not configuring the host keys of that the server offers.
       ssh_host_key_files:
         default: []
         type: list
@@ -317,14 +321,26 @@ argument_specs:
         default: 10:30:60
         description: Specifies the maximum number of concurrent unauthenticated connections
           to the SSH daemon.
+      ssh_macs_config:
+        default: true
+        description: Whether or not configuring the macs of the server.
+        type: bool
       ssh_macs:
         default: []
         type: list
         description: Change this list to overwrite macs. Defaults found in `defaults/main.yml`
+      ssh_kex_config:
+        default: true
+        description: Whether or not configuring the kexs of the server.
+        type: bool
       ssh_kex:
         default: []
         type: list
         description: Change this list to overwrite kexs. Defaults found in `defaults/main.yml`
+      ssh_ciphers_config:
+        default: true
+        description: Whether or not configuring the ciphers of the server.
+        type: bool
       ssh_ciphers:
         default: []
         type: list

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -39,26 +39,22 @@
   ansible.builtin.include_tasks: crypto_hostkeys.yml
   when:
     - ssh_server_hardening | bool
-    - ssh_host_key_config
-    - not ssh_host_key_files
+    - ssh_host_key_files is undefined
 
 - name: Set default for ssh_macs if not supplied
   ansible.builtin.include_tasks: crypto_macs.yml
   when:
-    - ssh_macs_config
-    - not ssh_macs
+    - ssh_macs is undefined
 
 - name: Set default for ssh_ciphers if not supplied
   ansible.builtin.include_tasks: crypto_ciphers.yml
   when:
-    - ssh_ciphers_config
-    - not ssh_ciphers
+    - ssh_ciphers is undefined
 
 - name: Set default for ssh_kex if not supplied
   ansible.builtin.include_tasks: crypto_kex.yml
   when:
-    - ssh_kex_config
-    - not ssh_kex
+    - ssh_kex is undefined
 
 - name: Create revoked_keys and set permissions to root/600
   ansible.builtin.template:

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -39,19 +39,26 @@
   ansible.builtin.include_tasks: crypto_hostkeys.yml
   when:
     - ssh_server_hardening | bool
+    - ssh_host_key_config
     - not ssh_host_key_files
 
 - name: Set default for ssh_macs if not supplied
   ansible.builtin.include_tasks: crypto_macs.yml
-  when: not ssh_macs
+  when:
+    - ssh_macs_config
+    - not ssh_macs
 
 - name: Set default for ssh_ciphers if not supplied
   ansible.builtin.include_tasks: crypto_ciphers.yml
-  when: not ssh_ciphers
+  when:
+    - ssh_ciphers_config
+    - not ssh_ciphers
 
 - name: Set default for ssh_kex if not supplied
   ansible.builtin.include_tasks: crypto_kex.yml
-  when: not ssh_kex
+  when:
+    - ssh_kex_config
+    - not ssh_kex
 
 - name: Create revoked_keys and set permissions to root/600
   ansible.builtin.template:

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -34,9 +34,11 @@ ListenAddress {{ address }}
 {% endfor %}
 
 # HostKeys are listed here.
-{% for key in ssh_host_key_files if ssh_host_key_config%}
+{% if ssh_host_key_files is defined and ssh_host_key_files -%}
+{%    for key in ssh_host_key_files %}
 HostKey {{ key }}
-{% endfor %}
+{%    endfor %}
+{% endif %}
 
 # HostCertificates are listed here.
 {% for certificate in ssh_host_certificates -%}
@@ -73,14 +75,22 @@ LogLevel {{ sshd_log_level }}
 # -- see: (http://net-ssh.github.com/net-ssh/classes/Net/SSH/Transport/CipherFactory.html)
 #
 {# This outputs 'Ciphers <list-of-ciphers>' if ssh_ciphers is defined or '#Ciphers' if ssh_ciphers is undefined -#}
-{{ 'Ciphers ' ~ ssh_ciphers|join(',') if ssh_ciphers and ssh_ciphers_config else 'Ciphers'|comment }}
+{% if ssh_ciphers is defined and ssh_ciphers -%}
+{{ 'Ciphers ' ~ ssh_ciphers|join(',') }}
+{% else -%}
+{{ 'Ciphers'|comment }}
+{% endif %}
 
 # **Hash algorithms** -- SHA-1 is formally deprecated by NIST in 2011 because of security issues.
 # Weak HMAC is sometimes required if older package versions are used
 # eg Ruby's Net::SSH at around 2.2.* doesn't support sha2 for hmac, so this will have to be set true in this case.
 #
 {# This outputs 'MACs <list-of-macs>' if ssh_macs is defined or '#MACs' if ssh_macs is undefined -#}
-{{ 'MACs ' ~ ssh_macs|join(',') if ssh_macs and ssh_macs_config else 'MACs'|comment }}
+{% if ssh_macs is defined and ssh_macs -%}
+{{ 'MACs ' ~ ssh_macs|join(',') }}
+{% else -%}
+{{ 'MACs'|comment }}
+{% endif %}
 
 {% if sshd_version is version('5.9', '<') %}
 # Alternative setting, if OpenSSH version is below v5.9
@@ -92,8 +102,12 @@ LogLevel {{ sshd_log_level }}
 # eg ruby's Net::SSH at around 2.2.* doesn't support sha2 for kex, so this will have to be set true in this case.
 # based on: https://bettercrypto.org/static/applied-crypto-hardening.pdf
 #
-{# This outputs 'KexAlgorithms <list-of-algos>' if ssh_kex is defined or '#KexAlgorithms' if ssh_kex is undefined #}
-{{ 'KexAlgorithms ' ~ ssh_kex|join(',') if ssh_kex and ssh_kex_config else 'KexAlgorithms'|comment }}
+{# This outputs 'KexAlgorithms <list-of-algos>' if ssh_kex is defined and ssh_kex or '#KexAlgorithms' if ssh_kex is undefined #}
+{% if ssh_kex is defined and ssh_kex -%}
+{{ 'KexAlgorithms ' ~ ssh_kex|join(',') }}
+{% else -%}
+{{ 'KexAlgorithms'|comment }}
+{% endif %}
 
 # Authentication
 # --------------

--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -34,7 +34,7 @@ ListenAddress {{ address }}
 {% endfor %}
 
 # HostKeys are listed here.
-{% for key in ssh_host_key_files %}
+{% for key in ssh_host_key_files if ssh_host_key_config%}
 HostKey {{ key }}
 {% endfor %}
 
@@ -73,14 +73,14 @@ LogLevel {{ sshd_log_level }}
 # -- see: (http://net-ssh.github.com/net-ssh/classes/Net/SSH/Transport/CipherFactory.html)
 #
 {# This outputs 'Ciphers <list-of-ciphers>' if ssh_ciphers is defined or '#Ciphers' if ssh_ciphers is undefined -#}
-{{ 'Ciphers ' ~ ssh_ciphers|join(',') if ssh_ciphers else 'Ciphers'|comment }}
+{{ 'Ciphers ' ~ ssh_ciphers|join(',') if ssh_ciphers and ssh_ciphers_config else 'Ciphers'|comment }}
 
 # **Hash algorithms** -- SHA-1 is formally deprecated by NIST in 2011 because of security issues.
 # Weak HMAC is sometimes required if older package versions are used
 # eg Ruby's Net::SSH at around 2.2.* doesn't support sha2 for hmac, so this will have to be set true in this case.
 #
 {# This outputs 'MACs <list-of-macs>' if ssh_macs is defined or '#MACs' if ssh_macs is undefined -#}
-{{ 'MACs ' ~ ssh_macs|join(',') if ssh_macs else 'MACs'|comment }}
+{{ 'MACs ' ~ ssh_macs|join(',') if ssh_macs and ssh_macs_config else 'MACs'|comment }}
 
 {% if sshd_version is version('5.9', '<') %}
 # Alternative setting, if OpenSSH version is below v5.9
@@ -93,7 +93,7 @@ LogLevel {{ sshd_log_level }}
 # based on: https://bettercrypto.org/static/applied-crypto-hardening.pdf
 #
 {# This outputs 'KexAlgorithms <list-of-algos>' if ssh_kex is defined or '#KexAlgorithms' if ssh_kex is undefined #}
-{{ 'KexAlgorithms ' ~ ssh_kex|join(',') if ssh_kex else 'KexAlgorithms'|comment }}
+{{ 'KexAlgorithms ' ~ ssh_kex|join(',') if ssh_kex and ssh_kex_config else 'KexAlgorithms'|comment }}
 
 # Authentication
 # --------------


### PR DESCRIPTION
Hello,

We would like to have more fine grained options on applying or not specific configurations.

This commit let the user choose to noop some configuration by setting their value to false.

Another option would have been to create more variables but I was reticent to do so.

Motivation for theses options are we may configure ourselves some (ssh host key regeneration in a templating system) or we are not ready for others (ssh_kex will break dist-upgrades, letting the operator without ssh).