### PR TITLE
Use Python venv for VM tests

### DIFF
--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -55,18 +55,16 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
-      - name: activate venv
-        run: |
-          source ~/.venv/ansible-collection-hardening/bin/activate
-
       - name: Install dependencies
         run: |
+          source ~/.venv/ansible-collection-hardening/bin/activate
           python -m pip install --no-cache-dir --upgrade pip
           pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
         run: |
+          source ~/.venv/ansible-collection-hardening/bin/activate
           pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'eneric/rocky8' || matrix.molecule_distro == 'generic/opensuse15'
@@ -77,6 +75,7 @@ jobs:
 
       - name: Test with molecule
         run: |
+          source ~/.venv/ansible-collection-hardening/bin/activate
           molecule --version
           molecule test -s os_hardening_vm
         env:

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -55,6 +55,22 @@ jobs:
           path: ansible_collections/devsec/hardening
           submodules: true
 
+      - name: activate venv
+        run: |
+          source ~/.venv/ansible-collection-hardening/bin/activate
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --no-cache-dir --upgrade pip
+          pip install -r requirements.txt
+        working-directory: ansible_collections/devsec/hardening
+
+      - name: Downgrade Ansible for Rocky 8 tests
+        run: |
+          pip install "ansible-core<2.17"
+        working-directory: ansible_collections/devsec/hardening
+        if: matrix.molecule_distro == 'eneric/rocky8' || matrix.molecule_distro == 'generic/opensuse15'
+
       - name: Update Vagrant Box
         run: |
           vagrant box update --box ${{ matrix.molecule_distro }} || true

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -68,7 +68,7 @@ jobs:
           source ~/.venv/ansible-collection-hardening/bin/activate
           pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
-        if: matrix.molecule_distro == 'eneric/rocky8' || matrix.molecule_distro == 'generic/opensuse15'
+        if: matrix.molecule_distro == 'generic/rocky8' || matrix.molecule_distro == 'generic/opensuse15'
 
       - name: Update Vagrant Box
         run: |

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -60,6 +60,7 @@ jobs:
           source ~/.venv/ansible-collection-hardening/bin/activate
           python -m pip install --no-cache-dir --upgrade pip
           pip install -r requirements.txt
+          pip install python-vagrant
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests


### PR DESCRIPTION
This way we can use the same Ansible version as defined in the repo and not the host packages.