### PR TITLE
feat: Corrected package name

### DIFF
--- a/roles/ssh_hardening/vars/Debian.yml
+++ b/roles/ssh_hardening/vars/Debian.yml
@@ -11,7 +11,7 @@ ssh_host_keys_owner: root
 ssh_host_keys_group: root
 ssh_host_keys_mode: "0600"
 ssh_selinux_packages:
-  - policycoreutils-python
+  - policycoreutils-python-utils
   - checkpolicy
 
 # true if SSH support Kerberos


### PR DESCRIPTION
`policycoreutils-python` does not exist and was corrected to `policycoreutils-python-utils`. Only tested on debian