### PR TITLE
Document correct quotes for ssh_permit_tunnel parameter

### DIFF
--- a/roles/ssh_hardening/meta/argument_specs.yml
+++ b/roles/ssh_hardening/meta/argument_specs.yml
@@ -65,8 +65,8 @@ argument_specs:
       ssh_permit_tunnel:
         default: 'no'
         description: Specifies whether tun(4) device forwarding is allowed. The argument
-          must be yes, point-to-point (layer 3), ethernet (layer 2), or no. Specifying
-          yes permits both point-to-point and ethernet.
+          must be "yes", point-to-point (layer 3), ethernet (layer 2), or "no". Specifying
+          yes permits both point-to-point and ethernet. - The quotes are required!
         choices:
           - 'no'
           - 'yes'


### PR DESCRIPTION
…cs.yml

ssh_permit_tunnel needs quotes otherwise we will end up with an error:
```
TASK [devsec.hardening.ssh_hardening : Create sshd_config and set permissions to root/600] **********************************************************************************************************************
fatal: [vampdock02]: FAILED! => {"changed": false, "checksum": "fe6b74e30b1a653f83c2cbe1dd1332c14bd55833", "exit_status": 255, "msg": "failed to validate", "stderr": "/home/debian/.ansible/tmp/ansible-tmp-1728530891.493071-72386-149151737175948/source line 123: bad PermitTunnel argument True\r\n", "stderr_lines": ["/home/debian/.ansible/tmp/ansible-tmp-1728530891.493071-72386-149151737175948/source line 123: bad PermitTunnel argument True"], "stdout": "", "stdout_lines": []}
```