### PR TITLE
Pin python dependencies and optimize GitHub Actions

### DIFF
--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -60,17 +60,14 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
-        run: |
-          sudo apt install git
-          python -m pip install --no-cache-dir --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
-        run: |
-          pip install "ansible-core<2.17"
+        run: pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8'
 
@@ -96,9 +93,7 @@ jobs:
             /home/runner/.ansible/roles
 
       - name: Test with molecule
-        run: |
-          molecule --version
-          molecule test -s mysql_hardening
+        run: molecule test -s mysql_hardening
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
         working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -59,17 +59,14 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
-        run: |
-          sudo apt install git
-          python -m pip install --no-cache-dir --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
-        run: |
-          pip install "ansible-core<2.17"
+        run: pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8'
 
@@ -85,9 +82,7 @@ jobs:
             /home/runner/.ansible/roles
 
       - name: Test with molecule
-        run: |
-          molecule --version
-          molecule test -s nginx_hardening
+        run: molecule test -s nginx_hardening
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
         working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -35,6 +35,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        include:
+          - molecule_distro: opensuse_tumbleweed
+            molecule_docker_command: "/usr/lib/systemd/systemd"
+        molecule_docker_command:
+          - "/lib/systemd/systemd"
         molecule_distro:
           - centosstream9
           - rocky8
@@ -47,7 +52,6 @@ jobs:
           - debian11
           - debian12
           - amazon2023
-          - opensuse_tumbleweed
           - arch
     steps:
       - name: Checkout repo
@@ -60,27 +64,20 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
-        run: |
-          sudo apt install git
-          python -m pip install --no-cache-dir --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
-        run: |
-          pip install "ansible-core<2.17"
+        run: pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8'
 
       - name: Test with molecule
-        run: |
-          if [ "$MOLECULE_DISTRO" = "opensuse_tumbleweed" ]; then
-            export MOLECULE_DOCKER_COMMAND="/usr/lib/systemd/systemd"
-          fi
-          molecule --version
-          molecule test -s os_hardening
+        run: molecule test -s os_hardening
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
+          MOLECULE_DOCKER_COMMAND: ${{ matrix.molecule_docker_command }}
         working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -38,8 +38,6 @@ jobs:
         include:
           - molecule_distro: opensuse_tumbleweed
             molecule_docker_command: "/usr/lib/systemd/systemd"
-        molecule_docker_command:
-          - "/lib/systemd/systemd"
         molecule_distro:
           - centosstream9
           - rocky8
@@ -53,6 +51,8 @@ jobs:
           - debian12
           - amazon2023
           - arch
+        molecule_docker_command:
+          - "/lib/systemd/systemd"
     steps:
       - name: Checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Test with molecule
         run: |
           source ~/.venv/ansible-collection-hardening/bin/activate
-          molecule --version
           molecule test -s os_hardening_vm
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}

--- a/.github/workflows/roles-readme.yml
+++ b/.github/workflows/roles-readme.yml
@@ -12,6 +12,7 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - 'roles/**/meta/argument_specs.yml'
       - 'roles/**/meta/main.yml'
+      - 'requirements.txt'
 
 jobs:
   readme:
@@ -32,12 +33,14 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
-      - name: Install aar_doc
-        run: pip3 install aar_doc
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        working-directory: ansible_collections/devsec/hardening
 
-      - name: Run aar_doc
-        run: aar_doc roles/${{ matrix.roles }} markdown
+      - name: Run aar-doc
+        run: aar-doc roles/${{ matrix.roles }} markdown
 
       - name: Output diff
         run: git diff roles/${{ matrix.roles }}/README.md

--- a/.github/workflows/roles-readme.yml
+++ b/.github/workflows/roles-readme.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r requirements.txt
-        working-directory: ansible_collections/devsec/hardening
 
       - name: Run aar-doc
         run: aar-doc roles/${{ matrix.roles }} markdown

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -41,8 +41,6 @@ jobs:
           #   molecule_docker_command: "/usr/lib/systemd/systemd"
           - molecule_distro: alpine
             molecule_docker_command: "/sbin/init"
-        molecule_docker_command:
-          - "/lib/systemd/systemd"
         molecule_distro:
           - centosstream9
           - rocky8
@@ -56,6 +54,8 @@ jobs:
           - debian12
           - amazon2023
           - arch
+        molecule_docker_command:
+          - "/lib/systemd/systemd"
     steps:
       - name: Checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -67,24 +67,19 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
-        run: |
-          sudo apt install git
-          python -m pip install --no-cache-dir --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
-        run: |
-          pip install "ansible-core<2.17"
+        run: pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8'
 
       - name: Test with molecule
-        run: |
-          molecule --version
-          molecule test -s ssh_hardening
+        run: molecule test -s ssh_hardening
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
           MOLECULE_DOCKER_COMMAND: ${{ matrix.molecule_docker_command }}

--- a/.github/workflows/ssh_hardening_bsd.yml
+++ b/.github/workflows/ssh_hardening_bsd.yml
@@ -47,13 +47,10 @@ jobs:
           submodules: true
 
       - name: Update Vagrant Box
-        run: |
-          vagrant box update --box generic/${{ matrix.molecule_distro }} || true
+        run: vagrant box update --box generic/${{ matrix.molecule_distro }} || true
 
       - name: Test with molecule
-        run: |
-          molecule --version
-          molecule test -s ssh_hardening_bsd
+        run: molecule test -s ssh_hardening_bsd
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
         working-directory: ansible_collections/devsec/hardening

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -41,8 +41,6 @@ jobs:
           #   molecule_docker_command: "/usr/lib/systemd/systemd"
           - molecule_distro: alpine
             molecule_docker_command: "/sbin/init"
-        molecule_docker_command:
-          - "/lib/systemd/systemd"
         molecule_distro:
           - centosstream9
           - rocky8
@@ -56,6 +54,8 @@ jobs:
           - debian12
           - amazon2023
           - arch
+        molecule_docker_command:
+          - "/lib/systemd/systemd"
     steps:
       - name: Checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -67,24 +67,19 @@ jobs:
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
-        run: |
-          sudo apt install git
-          python -m pip install --no-cache-dir --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
         working-directory: ansible_collections/devsec/hardening
 
       - name: Downgrade Ansible for Rocky 8 tests
-        run: |
-          pip install "ansible-core<2.17"
+        run: pip install "ansible-core<2.17"
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8'
 
       - name: Test with molecule
-        run: |
-          molecule --version
-          molecule test -s ssh_hardening_custom_tests
+        run: molecule test -s ssh_hardening_custom_tests
         env:
           MOLECULE_DISTRO: ${{ matrix.molecule_distro }}
           MOLECULE_DOCKER_COMMAND: ${{ matrix.molecule_docker_command }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-molecule
-molecule-plugins[docker]
-yamllint
+molecule==24.9.0
+molecule-plugins[docker]==23.5.3
 ansible-core==2.17.5
-ansible-lint
-docker
-flake8
-jmespath
+docker==7.1.0
+jmespath==1.0.1
+aar-doc==2.0.0


### PR DESCRIPTION
Pin all python dependencies and let them be managed by Renovate. This way we get more stable CI and don't need to log versions everytime.

Also shorten/optimize GHA workflows a bit.