### PR TITLE
Set number of warning days before password expires for existing users

### DIFF
--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: This Ansible role provides numerous security-related ssh configurations, providing all-round base protection.
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: "2.11"
+  min_ansible_version: "2.16"
   platforms:
     - name: EL
       versions:

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -36,6 +36,7 @@
     name: "{{ item }}"
     password_expire_min: "{{ os_auth_pw_min_age }}"
     password_expire_max: "{{ os_auth_pw_max_age }}"
+    password_expire_warn: "{{ os_auth_pw_warn_age }}"
   loop: "{{ regular_users }}"
   when:
     - os_user_pw_ageing
@@ -66,6 +67,7 @@
     name: "{{ item }}"
     password_expire_min: "{{ os_auth_pw_min_age }}"
     password_expire_max: "{{ os_auth_pw_max_age }}"
+    password_expire_warn: "{{ os_auth_pw_warn_age }}"
   loop: "{{ root_users }}"
   when:
     - os_rootuser_pw_ageing | bool


### PR DESCRIPTION
This is a follow-up of #628 - better late than never.

The `password_expire_warn` option has been added in ansible-core 2.16 (https://github.com/ansible/ansible/pull/79884). So we can now set the number of warning days before the user password expires for existing accounts, too.