### PR TITLE
Pin runner image to specific version to decouple from GitHub updates

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -3,9 +3,9 @@
 # exclude_paths included in this file are parsed relative to this file's location
 # and not relative to the CWD of execution. CLI arguments passed to the --exclude
 # option will be parsed relative to the CWD of execution.
+# add all waivers individually, since exclude_files does not support globs
 exclude_paths:
   - .cache/ # implicit unless exclude_paths is defined in config
-  # add all waivers individually, since exclude_files does not support globs
   - molecule/os_hardening/waivers.yaml
   - molecule/ssh_hardening_bsd/waivers_freebsd13.yaml
   - molecule/ssh_hardening_bsd/waivers_freebsd14.yaml

--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -3,9 +3,10 @@
 # exclude_paths included in this file are parsed relative to this file's location
 # and not relative to the CWD of execution. CLI arguments passed to the --exclude
 # option will be parsed relative to the CWD of execution.
-# add all waivers individually, since exclude_files does not support globs
 exclude_paths:
   - .cache/ # implicit unless exclude_paths is defined in config
+  - .ansible/ # somehow someone decided that the cache directory should be renamed
+  # add all waivers individually, since exclude_files does not support globs
   - molecule/os_hardening/waivers.yaml
   - molecule/ssh_hardening_bsd/waivers_freebsd13.yaml
   - molecule/ssh_hardening_bsd/waivers_freebsd14.yaml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -23,7 +23,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   ansible-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   enforce-label:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   deploy:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/prettier-md.yml
+++ b/.github/workflows/prettier-md.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   prettier-md:
     if: github.repository == 'dev-sec/ansible-collection-hardening'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 1
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   generate_changelog:
     name: create release draft
     if: github.repository == 'dev-sec/ansible-collection-hardening'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/roles-readme.yml
+++ b/.github/workflows/roles-readme.yml
@@ -17,7 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   readme:
     name: create roles readme
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         roles:

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/molecule/mysql_hardening/prepare.yml
+++ b/molecule/mysql_hardening/prepare.yml
@@ -33,7 +33,7 @@
       when: ansible_os_family == 'Debian'
 
     - name: Install required python packages on Suse
-      ansible.builtin.command: zypper -n install python-xml python3-rpm python3-PyMySQL
+      ansible.builtin.command: zypper -n install python311-rpm python311-PyMySQL
       changed_when: false
       when: ansible_os_family == 'Suse'
 

--- a/molecule/nginx_hardening/prepare.yml
+++ b/molecule/nginx_hardening/prepare.yml
@@ -7,12 +7,6 @@
     https_proxy: "{{ lookup('env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('env', 'no_proxy') | default(omit) }}"
   tasks:
-    - name: Install required tools on SuSE
-      community.general.zypper:
-        name: python-xml
-        state: present
-      when: ansible_facts.os_family == 'Suse'
-
     - name: Install required packages
       ansible.builtin.package:
         name: python3-apt

--- a/molecule/os_hardening/prepare.yml
+++ b/molecule/os_hardening/prepare.yml
@@ -20,7 +20,7 @@
 
     - name: Install required tools on SuSE
       # cannot use zypper module, since it depends on python-xml
-      ansible.builtin.command: zypper -n install python-xml awk
+      ansible.builtin.command: zypper -n install awk
       changed_when: false
       when: ansible_facts.os_family == 'Suse'
 

--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -50,12 +50,6 @@
         update_cache: true
       when: ansible_os_family == 'Debian'
 
-    - name: Install required tools on SuSE
-      # cannot use zypper module, since it depends on python-xml
-      ansible.builtin.command: zypper -n install python-xml
-      changed_when: false
-      when: ansible_facts.os_family == 'Suse'
-
     - name: Install required tools on fedora
       ansible.builtin.dnf:
         name:

--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -146,7 +146,7 @@ sysctl_config:
   # The PTRACE system is used for debugging.  With it, a single user process
   # can attach to any other dumpable process owned by the same user.  In the
   # case of malicious software, it is possible to use PTRACE to access
-  # credentials that exist in memory (re-using existing SSH connections,
+  # credentials that exist in memory (reusing existing SSH connections,
   # extracting GPG agent information, etc).
   #
   # A PTRACE scope of "0" is the more permissive mode.  A scope of "1" limits


### PR DESCRIPTION
This is ok, since Renovate will also mange updates of these.
suspected solution to our current problems with CI not working.