### PR TITLE
Accept strings and lists for ssh_allow_users

### DIFF
--- a/roles/ssh_hardening/templates/opensshd.conf.j2
+++ b/roles/ssh_hardening/templates/opensshd.conf.j2
@@ -171,7 +171,7 @@ DenyUsers {{ ssh_deny_users }}
 
 {% endif %}
 {% if ssh_allow_users %}
-AllowUsers {{ ssh_allow_users }}
+AllowUsers {{ ssh_allow_users if (ssh_allow_users is string) else (ssh_allow_users|join(' ')) }}
 
 {% endif %}
 {% if ssh_deny_groups %}


### PR DESCRIPTION
This makes our ssh_hardening role accept both strings and lists for `ssh_allow_users`.

@rndmh3ro WDYT?

Initially I thought this may be a good idea to allow more flexible use. But there is also an overlap with our documentation that states this should be a string since a long time. Also if we allow two types to be passed here we cannot use argument spec to check the variable anymore.

The alternative would be to add a type check to argument spec and simply fail before executing.

closes #838 