### PR TITLE
Fix: ForwardAgent j2 template space 

### DIFF
--- a/roles/ssh_hardening/templates/openssh.conf.j2
+++ b/roles/ssh_hardening/templates/openssh.conf.j2
@@ -91,7 +91,7 @@ StrictHostKeyChecking ask
 {% endif %}
 # Disable agent forwarding, since local agent could be accessed through forwarded connection.
 
-ForwardAgent {{ ((ssh_forward_agent) if ssh_forward_agent is defined else 'no')}} 
+ForwardAgent {{ ((ssh_forward_agent) if ssh_forward_agent is defined else 'no') }}
 
 
 # Disable X11 forwarding, since local X11 display could be accessed through forwarded connection.


### PR DESCRIPTION
Change:
- `ForwardAgent` j2 template space in `roles/ssh_hardening/templates/op
enssh.conf.j2`
