### PR TITLE
Adding option to force refresh of getent_passwd

### DIFF
--- a/roles/os_hardening/defaults/main.yml
+++ b/roles/os_hardening/defaults/main.yml
@@ -499,3 +499,7 @@ os_mnt_var_tmp_passno: ""
 # keep .netrc file for users in whitelist
 os_netrc_enabled: true
 os_netrc_whitelist_user: []
+
+# Set to True to force the refresh of user facts
+# Usefull if you are calling this role in a workflow and you need {{ getent_passwd }} to be updated
+os_getent_passwd_force_sync: False

--- a/roles/os_hardening/tasks/user_accounts.yml
+++ b/roles/os_hardening/tasks/user_accounts.yml
@@ -5,7 +5,8 @@
     # creates a dict for each user containing UID/HOMEDIR etc...
   # skip this task if getent was run before without specifying a key (single entry)
   when: getent_passwd is undefined or
-        getent_passwd | length <= 1
+        getent_passwd | length <= 1 or
+        os_getent_passwd_force_sync
 
 - name: Read local linux shadow database
   ansible.builtin.getent:


### PR DESCRIPTION
Hello,

This little addition can be usefull if like me you are using this role as a part of a workflow.

This workflow gets the getent facts at the beginning of his run but the users can be modified during it.
So I had this case where the os_hardening role was trying to run stuff on users which do not exist anymore.

Setting this fact could be an easy way to handle this behavior.

Thanks,
Julien.