### PR TITLE
fix: verify group exists

### DIFF
--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -96,7 +96,7 @@
     mountpoints_list: "{{ mountpoints_list + ['/dev', '/dev/shm', '/run', '/tmp'] }}"
 
 - name: Define filesystems variable
-  set_fact:
+  ansible.builtin.set_fact:
     filesystems:
       - path: /boot
         src: "{{ os_mnt_boot_src }}"
@@ -200,7 +200,7 @@
         passno: "{{ os_mnt_var_tmp_passno }}"
 
 - name: Extract distinct groups from filesystems
-  set_fact:
+  ansible.builtin.set_fact:
     distinct_groups: "{{ filesystems | map(attribute='group') | unique | list }}"
 
 - name: Ensure all distinct groups exist


### PR DESCRIPTION
The purpose of this PR is to fix an issue that is there when try to change the ownership of file systems.
Currently, depending on different versions of Ubuntu, the syslog group can or cannot be there. Therefore, I added a check and eventually create the missing groups.
This is linked to #614 and #746.

I am not sure that my approach is the correct one. Maybe, if a group does not exists, we should just use 'root' instead. What is your advice?