### PR TITLE
Write sysctl config to separate file

### DIFF
--- a/roles/os_hardening/tasks/sysctl.yml
+++ b/roles/os_hardening/tasks/sysctl.yml
@@ -1,6 +1,4 @@
 ---
-
-
 - name: Set Daemon umask, do config for rhel-family | NSA 2.2.4.1
   ansible.builtin.template:
     src: etc/sysconfig/rhel_sysconfig_init.j2


### PR DESCRIPTION
Write our sysctl config to separate file, since newer distributions no longer use the global `/etc/sysctl.conf` file. All older distributions seem to already support reading from `/etc/sysctl.d` so this should be no breaking change.