### PR TITLE
Update ArchLinux test environment before testing

### DIFF
--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -80,7 +80,6 @@
         upgrade: true
       when: ansible_facts.os_family == 'Archlinux'
 
-
     - name: Install required tools on RHEL # noqa ignore-errors
       ansible.builtin.dnf:
         name:


### PR DESCRIPTION
Update Arch packages and Keyrings to avoid problems when installing Ansible and dependencies.