### PR TITLE
fix: replace deprecated community.general.yaml callback plugin

### DIFF
--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
             pip install "ansible-core<2.17"
             ansible-galaxy collection install 'community.crypto:<3.0.0'
+            ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8' || matrix.molecule_distro == 'almalinux8'
 

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
             pip install "ansible-core<2.17"
             ansible-galaxy collection install 'community.crypto:<3.0.0'
+            ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8' || matrix.molecule_distro == 'almalinux8'
 

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
             pip install "ansible-core<2.17"
             ansible-galaxy collection install 'community.crypto:<3.0.0'
+            ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8' || matrix.molecule_distro == 'almalinux8'
 

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -73,6 +73,7 @@ jobs:
           source ~/.venv/ansible-collection-hardening/bin/activate
           pip install "ansible-core<2.17"
           ansible-galaxy collection install 'community.crypto:<3.0.0'
+          ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: >
           matrix.molecule_distro == 'generic/rocky8' ||

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
             pip install "ansible-core<2.17"
             ansible-galaxy collection install 'community.crypto:<3.0.0'
+            ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8' || matrix.molecule_distro == 'almalinux8'
 

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
             pip install "ansible-core<2.17"
             ansible-galaxy collection install 'community.crypto:<3.0.0'
+            ansible-galaxy collection install 'community.general:<12.0.0'
         working-directory: ansible_collections/devsec/hardening
         if: matrix.molecule_distro == 'rocky8' || matrix.molecule_distro == 'almalinux8'
 

--- a/molecule/mysql_hardening/molecule.yml
+++ b/molecule/mysql_hardening/molecule.yml
@@ -22,7 +22,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
 verifier:
   name: ansible
 

--- a/molecule/nginx_hardening/molecule.yml
+++ b/molecule/nginx_hardening/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
 verifier:
   name: ansible
 

--- a/molecule/os_hardening/molecule.yml
+++ b/molecule/os_hardening/molecule.yml
@@ -17,7 +17,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
 verifier:
   name: ansible
 

--- a/molecule/os_hardening_vm/molecule.yml
+++ b/molecule/os_hardening_vm/molecule.yml
@@ -24,7 +24,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
       # Workaround for https://github.com/ansible-community/molecule-plugins/issues/301
       library: "${MOLECULE_PROJECT_DIRECTORY}/plugins/modules:/usr/share/ansible:${MOLECULE_VAGRANT_PLUGIN_DIR}"
 verifier:

--- a/molecule/ssh_hardening/molecule.yml
+++ b/molecule/ssh_hardening/molecule.yml
@@ -17,7 +17,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
   inventory:
     host_vars:
       # https://molecule.readthedocs.io/en/latest/examples.html#docker-with-non-privileged-user

--- a/molecule/ssh_hardening_bsd/molecule.yml
+++ b/molecule/ssh_hardening_bsd/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
       # Workaround for https://github.com/ansible-community/molecule-plugins/issues/301
       library: "${MOLECULE_PROJECT_DIRECTORY}/plugins/modules:/usr/share/ansible:${MOLECULE_VAGRANT_PLUGIN_DIR}"
 verifier:

--- a/molecule/ssh_hardening_custom_tests/molecule.yml
+++ b/molecule/ssh_hardening_custom_tests/molecule.yml
@@ -17,7 +17,7 @@ provisioner:
   config_options:
     defaults:
       interpreter_python: auto_silent
-      callbacks_enabled: profile_tasks, timer, yaml
+      callbacks_enabled: profile_tasks, timer
 verifier:
   name: ansible
 


### PR DESCRIPTION
Replace the removed community.general.yaml callback with the `result_format` option in ansible.builtin.default callback plugin.

The community.general.yaml callback plugin has been removed in community.general 12.0.0. The replacement is to use `result_format=yaml` with the default callback plugin from ansible-core 2.13+.