### PR TITLE
fix flaky failures on Ubuntu 24.04 and newer by disabling sshd socket activation first

### DIFF
--- a/roles/ssh_hardening/tasks/disable-systemd-socket.yml
+++ b/roles/ssh_hardening/tasks/disable-systemd-socket.yml
@@ -1,4 +1,11 @@
 ---
+- name: Disable systemd-socket activation
+  ansible.builtin.systemd:
+    name: ssh.socket
+    state: stopped
+    enabled: false
+    masked: true
+
 - name: Remove ssh service systemd-socket file
   ansible.builtin.file:
     path: "{{ item }}"
@@ -8,9 +15,8 @@
     - /etc/systemd/system/ssh.service.requires/ssh.socket
     - /etc/systemd/system/sockets.target.wants/ssh.socket
 
-- name: Disable systemd-socket activation
+- name: Ensure ssh service is started after disabling socket activation
   ansible.builtin.systemd:
-    name: ssh.socket
-    state: stopped
-    enabled: false
-    masked: true
+    name: "{{ sshd_service_name }}"
+    state: started
+    enabled: true


### PR DESCRIPTION
Related to https://github.com/dev-sec/ansible-collection-hardening/issues/854

Recently devsec hardening started to fail on fresh Ubuntu 24.04 machines. The ones we use come from Azure and update automatically, which probably explains why we suddenly started seeing this issue. Disabling the configuration first followed by delete plus reload seems to have fixes the issue in our deployments. 

I'm guessing ansible keeps opening connections and the socket activation triggers as we didn't reload configuration. I don't know why just reloading the daemon wasn't enough after deleting the configuration though. Without these changes the sshd process is left in some dead state where it's still listening on the socket but refusing all connections making systemd unable to restart it.

I also locally tested these changes on Ubuntu 24.04 with molecule using this branch: https://github.com/dev-sec/ansible-collection-hardening/pull/878