### PR TITLE
Update supported OS versions to current Fedora (42/43/44) and Ubuntu (22.04/24.04/26.04)

### DIFF
--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -44,7 +44,6 @@ jobs:
           - rocky8
           - rocky9
           # - rocky10 # problem with baseline
-          - ubuntu2004
           - ubuntu2204
           - ubuntu2404
           - debian11

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -46,7 +46,7 @@ jobs:
           # - rocky10 # problem with baseline
           - ubuntu2204
           - ubuntu2404
-          - ubuntu2604
+          # - ubuntu2604 # problem with test setup
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/mysql_hardening.yml
+++ b/.github/workflows/mysql_hardening.yml
@@ -46,6 +46,7 @@ jobs:
           # - rocky10 # problem with baseline
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -43,7 +43,6 @@ jobs:
           - rocky8
           - rocky9
           - rocky10
-          - ubuntu2004
           - ubuntu2204
           - ubuntu2404
           - debian11

--- a/.github/workflows/nginx_hardening.yml
+++ b/.github/workflows/nginx_hardening.yml
@@ -45,6 +45,7 @@ jobs:
           - rocky10
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -48,7 +48,6 @@ jobs:
           - rocky10
           - fedora39
           - fedora40
-          - ubuntu2004
           - ubuntu2204
           - ubuntu2404
           - debian11

--- a/.github/workflows/os_hardening.yml
+++ b/.github/workflows/os_hardening.yml
@@ -46,10 +46,12 @@ jobs:
           - rocky8
           - rocky9
           - rocky10
-          - fedora39
-          - fedora40
+          - fedora42
+          - fedora43
+          - fedora44
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -46,7 +46,6 @@ jobs:
           - generic/rocky9
           - fedora/39-cloud-base
           - fedora/40-cloud-base
-          - generic/ubuntu2004
           - generic/ubuntu2204
           - alvistack/ubuntu-24.04
           - generic/debian11

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -44,9 +44,8 @@ jobs:
           - generic/centos9s
           - generic/rocky8
           - generic/rocky9
-          - fedora/42-cloud-base
-          - fedora/43-cloud-base
-          - fedora/44-cloud-base
+          - alvistack/fedora-42
+          - alvistack/fedora-43
           - generic/ubuntu2204
           - alvistack/ubuntu-24.04
           - alvistack/ubuntu-26.04

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -44,12 +44,15 @@ jobs:
           - generic/centos9s
           - generic/rocky8
           - generic/rocky9
-          - fedora/39-cloud-base
-          - fedora/40-cloud-base
+          - fedora/42-cloud-base
+          - fedora/43-cloud-base
+          - fedora/44-cloud-base
           - generic/ubuntu2204
           - alvistack/ubuntu-24.04
+          - alvistack/ubuntu-26.04
           - generic/debian11
           - generic/debian12
+          - generic/debian13
           - generic/opensuse15
           - generic/arch
     steps:

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -51,7 +51,7 @@ jobs:
           - alvistack/ubuntu-26.04
           - generic/debian11
           - generic/debian12
-          - generic/debian13
+          - cloud-image/debian-13
           - generic/opensuse15
           - generic/arch
     steps:

--- a/.github/workflows/os_hardening_vm.yml
+++ b/.github/workflows/os_hardening_vm.yml
@@ -45,10 +45,10 @@ jobs:
           - generic/rocky8
           - generic/rocky9
           - alvistack/fedora-42
-          - alvistack/fedora-43
+          # - alvistack/fedora-43 # no compatible test image
           - generic/ubuntu2204
           - alvistack/ubuntu-24.04
-          - alvistack/ubuntu-26.04
+          # - alvistack/ubuntu-26.04 # no compatible test image
           - generic/debian11
           - generic/debian12
           - cloud-image/debian-13

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -51,7 +51,6 @@ jobs:
           - rocky10
           - fedora39
           - fedora40
-          - ubuntu2004
           - ubuntu2204
           - ubuntu2404
           - debian11

--- a/.github/workflows/ssh_hardening.yml
+++ b/.github/workflows/ssh_hardening.yml
@@ -49,10 +49,12 @@ jobs:
           - rocky8
           - rocky9
           - rocky10
-          - fedora39
-          - fedora40
+          - fedora42
+          - fedora43
+          - fedora44
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -51,7 +51,6 @@ jobs:
           - rocky10
           - fedora39
           - fedora40
-          - ubuntu2004
           - ubuntu2204
           - ubuntu2404
           - debian11

--- a/.github/workflows/ssh_hardening_custom_tests.yml
+++ b/.github/workflows/ssh_hardening_custom_tests.yml
@@ -49,10 +49,12 @@ jobs:
           - rocky8
           - rocky9
           - rocky10
-          - fedora39
-          - fedora40
+          - fedora42
+          - fedora43
+          - fedora44
           - ubuntu2204
           - ubuntu2404
+          - ubuntu2604
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/ssh_hardening_vm.yml
+++ b/.github/workflows/ssh_hardening_vm.yml
@@ -39,7 +39,6 @@ jobs:
       matrix:
         molecule_distro:
           - generic/openbsd7
-          - generic/freebsd13
           - generic/freebsd14
           - cloud-image/debian-13
           - cloud-image/ubuntu-24.04

--- a/.github/workflows/ssh_hardening_vm.yml
+++ b/.github/workflows/ssh_hardening_vm.yml
@@ -40,7 +40,6 @@ jobs:
         molecule_distro:
           - generic/openbsd7
           - generic/freebsd14
-          - generic/freebsd15
           - cloud-image/debian-13
           - cloud-image/ubuntu-24.04
           - cloud-image/ubuntu-26.04

--- a/.github/workflows/ssh_hardening_vm.yml
+++ b/.github/workflows/ssh_hardening_vm.yml
@@ -40,8 +40,10 @@ jobs:
         molecule_distro:
           - generic/openbsd7
           - generic/freebsd14
+          - generic/freebsd15
           - cloud-image/debian-13
           - cloud-image/ubuntu-24.04
+          - cloud-image/ubuntu-26.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This collection provides battle tested hardening for:
   - AlmaLinux 8/9/10
   - Rocky Linux 8/9/10
   - Debian 11/12/13
-  - Ubuntu 20.04/22.04/24.04
+  - Ubuntu 22.04/24.04
   - Amazon Linux (some roles supported)
   - Arch Linux (some roles supported)
   - Fedora 39/40 (some roles supported)

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This collection provides battle tested hardening for:
   - AlmaLinux 8/9/10
   - Rocky Linux 8/9/10
   - Debian 11/12/13
-  - Ubuntu 22.04/24.04
+  - Ubuntu 22.04/24.04/26.04
   - Amazon Linux (some roles supported)
   - Arch Linux (some roles supported)
-  - Fedora 39/40 (some roles supported)
+  - Fedora 42/43/44 (some roles supported)
   - Suse Tumbleweed (some roles supported)
 - MySQL
   - MariaDB >= 5.5.65, >= 10.1.45, >= 10.3.17

--- a/molecule/mysql_hardening/converge.yml
+++ b/molecule/mysql_hardening/converge.yml
@@ -15,14 +15,6 @@
         - ansible_facts.distribution == "Ubuntu"
         - ansible_facts.distribution_major_version|int > 19
 
-    - name: Determine required MySQL Python libraries.
-      ansible.builtin.set_fact:
-        mysql_python_package_debian: "{% if 'python3' in ansible_python_interpreter | default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
-      when:
-        - mysql_python_package_debian is not defined
-        - ansible_facts.distribution != "Ubuntu"
-        - ansible_facts.distribution_major_version|int < 20
-
     - name: Use Python 3 on Suse
       ansible.builtin.set_fact:
         ansible_python_interpreter: /usr/bin/python3

--- a/molecule/mysql_hardening/prepare.yml
+++ b/molecule/mysql_hardening/prepare.yml
@@ -51,14 +51,6 @@
         - ansible_facts.distribution == "Ubuntu"
         - ansible_facts.distribution_major_version|int > 19
 
-    - name: Determine required MySQL Python libraries.
-      ansible.builtin.set_fact:
-        mysql_python_package_debian: "{% if 'python3' in ansible_python_interpreter | default('') %}python3-mysqldb{% else %}python-mysqldb{% endif %}"
-      when:
-        - mysql_python_package_debian is not defined
-        - ansible_facts.distribution != "Ubuntu"
-        - ansible_facts.distribution_major_version|int < 20
-
     - name: Install required MySQL Python libraries on RHEL
       ansible.builtin.dnf:
         name: "{% if 'python3' in ansible_python_interpreter | default('') %}python36-PyMySQL{% else %}python2-PyMySQL{% endif %}"

--- a/molecule/mysql_hardening/prepare_tasks/mysql_users.yml
+++ b/molecule/mysql_hardening/prepare_tasks/mysql_users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create users for test
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query:
       - CREATE USER 'user'@'delete';
       - CREATE USER 'user'@'127.0.0.1';
@@ -15,7 +15,7 @@
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
 
 - name: Detect role support on MySQL
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT 1 FROM information_schema.COLUMNS
                 WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user'
@@ -24,7 +24,7 @@
   register: mysql_role_support
 
 - name: Create roles for test
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query:
       - CREATE ROLE 'role_keep';
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"

--- a/molecule/mysql_hardening/requirements.yml
+++ b/molecule/mysql_hardening/requirements.yml
@@ -2,8 +2,3 @@
 roles:
   - name: dev-sec.mysql
     version: master
-
-collections:
-  - name: https://github.com/ansible-collections/community.mysql.git
-    type: git
-    version: main

--- a/molecule/mysql_hardening/verify_tasks/mysql_users.yml
+++ b/molecule/mysql_hardening/verify_tasks/mysql_users.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get all users from MySQL server
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT CONCAT(USER, '@', HOST) AS users FROM mysql.user;
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
@@ -25,7 +25,7 @@
       - '"user@192.168.%" in mysql_users_list'
 
 - name: Detect role support on MySQL
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT 1 FROM information_schema.COLUMNS
                 WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user'

--- a/molecule/os_hardening/prepare_tasks/pw_ageing.yml
+++ b/molecule/os_hardening/prepare_tasks/pw_ageing.yml
@@ -3,8 +3,10 @@
   user:
     name: pw_no_ageing
     password: $6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1
+    password_expire_max: "-1"
 
 - name: Create user those password ageing should be changed
   user:
     name: pw_ageing
     password: $6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1
+    password_expire_max: "-1"

--- a/molecule/os_hardening/verify_tasks/pw_ageing.yml
+++ b/molecule/os_hardening/verify_tasks/pw_ageing.yml
@@ -4,6 +4,11 @@
   changed_when: false
   register: expiry_date
 
+
+- name: Check that the expiry date of pw_no_ageing is "never"
+  ansible.builtin.debug:
+    msg: "{{ expiry_date }}"
+
 - name: Check that the expiry date of pw_no_ageing is "never"
   ansible.builtin.assert:
     that:

--- a/molecule/os_hardening/verify_tasks/pw_ageing.yml
+++ b/molecule/os_hardening/verify_tasks/pw_ageing.yml
@@ -4,11 +4,6 @@
   changed_when: false
   register: expiry_date
 
-
-- name: Check that the expiry date of pw_no_ageing is "never"
-  ansible.builtin.debug:
-    msg: "{{ expiry_date }}"
-
 - name: Check that the expiry date of pw_no_ageing is "never"
   ansible.builtin.assert:
     that:

--- a/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
+++ b/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
@@ -67,6 +67,10 @@
   register: output
   ignore_errors: true
 
+- name: Debug
+  ansible.builtin.debug:
+    msg: "{{ output }}"
+
 - name: Assert check unsuccessful login
   ansible.builtin.assert:
     that:

--- a/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
+++ b/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
@@ -67,10 +67,6 @@
   register: output
   ignore_errors: true
 
-- name: Debug
-  ansible.builtin.debug:
-    msg: "{{ output }}"
-
 - name: Assert check unsuccessful login
   ansible.builtin.assert:
     that:

--- a/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
+++ b/molecule/os_hardening/verify_tasks/ssh_auth_locked.yml
@@ -84,7 +84,7 @@
   ansible.builtin.assert:
     that:
       - output.rc | int == 5
-      - output.stderr | length == 0
+      - "'(password expired)' in output.stderr"
       - output.stdout | length == 0
   when:
     - ansible_facts.os_family == "Suse"

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -35,6 +35,8 @@
     - name: Overrides for Debian 13 image
       ansible.builtin.set_fact:
         os_mnt_tmp_enabled: true
+        os_mnt_tmp_src: tmpfs
+        os_mnt_tmp_filesystem: tmpfs
       when:
         - ansible_facts.distribution == 'Debian'
         - ansible_facts.distribution_major_version|int == 13

--- a/molecule/os_hardening_vm/converge.yml
+++ b/molecule/os_hardening_vm/converge.yml
@@ -32,6 +32,13 @@
         - ansible_facts.distribution == 'Fedora'
         - ansible_facts.distribution_major_version|int == 40
 
+    - name: Overrides for Debian 13 image
+      ansible.builtin.set_fact:
+        os_mnt_tmp_enabled: true
+      when:
+        - ansible_facts.distribution == 'Debian'
+        - ansible_facts.distribution_major_version|int == 13
+
     - name: Include os_hardening role
       ansible.builtin.include_role:
         name: devsec.hardening.os_hardening

--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -9,6 +9,11 @@
       changed_when: false
       when: lookup('env', 'MOLECULE_DISTRO') == 'generic/arch'
 
+    - name: Update OS
+      ansible.builtin.raw: pacman --noconfirm -Suy
+      changed_when: false
+      when: lookup('env', 'MOLECULE_DISTRO') == 'generic/arch'
+
     - name: Install python, since it's not installed by default
       ansible.builtin.raw: pacman --noconfirm -Sy python
       changed_when: false

--- a/molecule/os_hardening_vm/prepare.yml
+++ b/molecule/os_hardening_vm/prepare.yml
@@ -4,6 +4,11 @@
   become: true
   gather_facts: false
   tasks:
+    - name: Update keyring
+      ansible.builtin.raw: pacman --noconfirm -Sy archlinux-keyring
+      changed_when: false
+      when: lookup('env', 'MOLECULE_DISTRO') == 'generic/arch'
+
     - name: Install python, since it's not installed by default
       ansible.builtin.raw: pacman --noconfirm -Sy python
       changed_when: false

--- a/molecule/ssh_hardening_vm/waivers_almalinux-10.yaml
+++ b/molecule/ssh_hardening_vm/waivers_almalinux-10.yaml
@@ -1,2 +1,3 @@
----
-{}
+unrelated:
+  run: false
+  justification: "cinc-auditor needs at least one waived control"

--- a/molecule/ssh_hardening_vm/waivers_debian-13.yaml
+++ b/molecule/ssh_hardening_vm/waivers_debian-13.yaml
@@ -1,2 +1,3 @@
----
-{}
+unrelated:
+  run: false
+  justification: "cinc-auditor needs at least one waived control"

--- a/molecule/ssh_hardening_vm/waivers_freebsd13.yaml
+++ b/molecule/ssh_hardening_vm/waivers_freebsd13.yaml
@@ -1,3 +1,0 @@
-sshd-45:
-  run: false
-  justification: "PrintLastLog is broken on FreeBSD. see: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=209441"

--- a/molecule/ssh_hardening_vm/waivers_ubuntu-24.04.yaml
+++ b/molecule/ssh_hardening_vm/waivers_ubuntu-24.04.yaml
@@ -1,2 +1,3 @@
----
-{}
+unrelated:
+  run: false
+  justification: "cinc-auditor needs at least one waived control"

--- a/molecule/ssh_hardening_vm/waivers_ubuntu-26.04.yaml
+++ b/molecule/ssh_hardening_vm/waivers_ubuntu-26.04.yaml
@@ -1,0 +1,3 @@
+unrelated:
+  run: false
+  justification: "cinc-auditor needs at least one waived control"

--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -28,7 +28,7 @@ Further information is available at [Deutsche Telekom (German)](http://www.telek
 - EL
   - 8, 9, 10
 - Ubuntu
-  - focal, jammy, noble
+  - jammy, noble
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -28,7 +28,7 @@ Further information is available at [Deutsche Telekom (German)](http://www.telek
 - EL
   - 8, 9, 10
 - Ubuntu
-  - jammy, noble
+  - jammy, noble, resolute
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/mysql_hardening/README.md
+++ b/roles/mysql_hardening/README.md
@@ -28,7 +28,7 @@ Further information is available at [Deutsche Telekom (German)](http://www.telek
 - EL
   - 8, 9, 10
 - Ubuntu
-  - jammy, noble, resolute
+  - jammy, noble
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - "10"
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
     - name: Debian

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
       versions:
         - jammy
         - noble
-        - resolute
     - name: Debian
       versions:
         - trixie

--- a/roles/mysql_hardening/meta/main.yml
+++ b/roles/mysql_hardening/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - jammy
         - noble
+        - resolute
     - name: Debian
       versions:
         - trixie

--- a/roles/mysql_hardening/tasks/configure.yml
+++ b/roles/mysql_hardening/tasks/configure.yml
@@ -14,7 +14,7 @@
     state: directory
     owner: "{{ mysql_hardening_user }}"
     group: "{{ mysql_hardening_user }}"
-    mode: "0750"
+    mode: '{{ mysql_hardening_datadir_permissions | default("0750") }}'
   when: item is defined and item != ""
   loop:
     - "{{ mysql_settings.settings.datadir }}"

--- a/roles/mysql_hardening/tasks/main.yml
+++ b/roles/mysql_hardening/tasks/main.yml
@@ -39,13 +39,13 @@
   when: not mysql_distribution is defined
 
 - name: Check which MySQL/MariaDB version is used
-  community.mysql.mysql_info:
+  ansible.mysql.mysql_info:
     filter: version
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_version
 
 - name: Check MySQL/MariaDB settings
-  community.mysql.mysql_info:
+  ansible.mysql.mysql_info:
     filter: settings
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   register: mysql_settings

--- a/roles/mysql_hardening/tasks/mysql_secure_installation.yml
+++ b/roles/mysql_hardening/tasks/mysql_secure_installation.yml
@@ -5,7 +5,7 @@
   when: mysql_root_password == '-----====>SetR00tPa$$wordH3r3!!!<====-----'
 
 - name: Ensure that the root password is present
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: root
     host_all: true
     password: "{{ mysql_root_password | mandatory }}"
@@ -20,14 +20,14 @@
   tags: my_cnf
 
 - name: Ensure that the test database is absent
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: test
     state: absent
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"
   when: mysql_remove_test_database
 
 - name: Ensure that anonymous users are absent
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: ""
     state: absent
     host_all: true
@@ -35,7 +35,7 @@
   when: mysql_remove_anonymous_users
 
 - name: Ensure that root can only login from localhost
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       DELETE
       FROM mysql.user
@@ -47,7 +47,7 @@
   when: mysql_remove_remote_root
 
 - name: Detect role support on MySQL version >= 5.7.6 or Mariadb version >= 10.4.0
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT 1 FROM information_schema.COLUMNS
                 WHERE TABLE_SCHEMA = 'mysql' AND TABLE_NAME = 'user'
@@ -57,7 +57,7 @@
   check_mode: false
 
 - name: Get all users that have no authentication_string on MySQL version >= 5.7.6 or Mariadb version >= 10.4.0
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT CONCAT(QUOTE(USER), '@', QUOTE(HOST)) AS user
       FROM mysql.user
@@ -76,7 +76,7 @@
     is version('10.4.0', '>='))
 
 - name: Get all users that have no password or authentication_string on MySQL version < 5.7.6 or Mariadb version < 10.4.0
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query: >
       SELECT CONCAT(QUOTE(USER), '@', QUOTE(HOST)) AS user
       FROM mysql.user
@@ -97,7 +97,7 @@
     version('10.4.0', '<'))
 
 - name: Ensure that there are no users without password or authentication_string
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     query:
       - DROP USER {{ item.user }}
     login_unix_socket: "{{ login_unix_socket | default(omit) }}"

--- a/roles/mysql_hardening/vars/Suse.yml
+++ b/roles/mysql_hardening/vars/Suse.yml
@@ -6,5 +6,7 @@ mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'
 mysql_cnf_owner: 'root'  # owner of /etc/my.cnf.d/*.cnf files
 mysql_cnf_group: 'mysql'  # owner of /etc/my.cnf.d/*.cnf files
 
+mysql_hardening_datadir_permissions: "0700"
+
 mysql_hardening_group: 'mysql'
 login_unix_socket: '/run/mysql/mysql.sock'

--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -21,7 +21,7 @@ It works with the following nginx-roles, including, but not limited to:
 - EL
   - 8, 9, 10
 - Ubuntu
-  - focal, jammy, noble
+  - jammy, noble
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/nginx_hardening/README.md
+++ b/roles/nginx_hardening/README.md
@@ -21,7 +21,7 @@ It works with the following nginx-roles, including, but not limited to:
 - EL
   - 8, 9, 10
 - Ubuntu
-  - jammy, noble
+  - jammy, noble, resolute
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/nginx_hardening/meta/main.yml
+++ b/roles/nginx_hardening/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - "10"
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
     - name: Debian

--- a/roles/nginx_hardening/meta/main.yml
+++ b/roles/nginx_hardening/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - jammy
         - noble
+        - resolute
     - name: Debian
       versions:
         - trixie

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -161,7 +161,7 @@ This role is mostly based on guides by:
 - EL
   - 8, 9, 10
 - Ubuntu
-  - focal, jammy, noble
+  - jammy, noble
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/os_hardening/README.md
+++ b/roles/os_hardening/README.md
@@ -161,7 +161,7 @@ This role is mostly based on guides by:
 - EL
   - 8, 9, 10
 - Ubuntu
-  - jammy, noble
+  - jammy, noble, resolute
 - Debian
   - trixie, bookworm, bullseye
 - Amazon

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - "10"
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
     - name: Debian

--- a/roles/os_hardening/meta/main.yml
+++ b/roles/os_hardening/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - jammy
         - noble
+        - resolute
     - name: Debian
       versions:
         - trixie

--- a/roles/os_hardening/templates/etc/login.defs.j2
+++ b/roles/os_hardening/templates/etc/login.defs.j2
@@ -5,7 +5,7 @@
 #
 # Three items must be defined:  `MAIL_DIR`, `ENV_SUPATH`, and `ENV_PATH`. If unspecified, some arbitrary (and possibly incorrect) value will be assumed.  All other items are optional - if not specified then the described action or option will be inhibited.
 #
-# Comment lines (lines beginning with `#`) and blank lines are ignored.
+# Comment lines and blank lines are ignored.
 #
 #-- Modified for Linux.  --marekm
 
@@ -35,7 +35,7 @@ FAILLOG_ENAB      yes
 
 # Enable display of unknown usernames when login failures are recorded.
 #
-# *WARNING*: Unknown usernames may become world readable. See #290803 and #298773 for details about how this could become a security concern
+# *WARNING*: Unknown usernames may become world readable. See 290803 and 298773 for details about how this could become a security concern
 LOG_UNKFAIL_ENAB  no
 
 # Enable logging of successful logins
@@ -56,7 +56,7 @@ SYSLOG_SG_ENAB    yes
 # If defined, login failures will be logged here in a utmp format last, when invoked as lastb, will read `/var/log/btmp`, so...
 FTMP_FILE         /var/log/btmp
 
-# If defined, the command name to display when running "su -".  For # example, if this is defined as "su" then a "ps" will display the command is "-su".  If not defined, then "ps" would display the name of the shell actually being run, e.g. something like "-sh".
+# If defined, the command name to display when running "su -".  For example, if this is defined as "su" then a "ps" will display the command is "-su".  If not defined, then "ps" would display the name of the shell actually being run, e.g. something like "-sh".
 SU_NAME           su
 
 # If defined, file which inhibits all the usual chatter during the login sequence.  If a full pathname, then hushed mode will be enabled if the user's name or shell are found in the file.  If not a full pathname, then hushed mode will be enabled if the file exists in the user's home directory.
@@ -96,7 +96,7 @@ KILLCHAR          025
 UMASK             {{ os_env_umask }}
 
 # Enable setting of the umask group bits to be the same as owner bits (examples: `022` -> `002`, `077` -> `007`) for non-root users, if the uid is the same as gid, and username is the same as the primary group name.
-# If set to yes, userdel will remove the user´s group if it contains no more members, and useradd will create by default a group with the name of the user.
+# If set to yes, userdel will remove the user's group if it contains no more members, and useradd will create by default a group with the name of the user.
 USERGROUPS_ENAB   yes
 
 

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -50,7 +50,7 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
 - EL
   - 8, 9, 10
 - Ubuntu
-  - focal, jammy, noble
+  - jammy, noble
 - Debian
   - trixie, bookworm, bullseye
 - Alpine
@@ -59,7 +59,7 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
 - ArchLinux
 - SmartOS
 - FreeBSD
-  - 13.2, 14.0
+  - 14.0
 - OpenBSD
   - 7.0
 

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -50,7 +50,7 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
 - EL
   - 8, 9, 10
 - Ubuntu
-  - jammy, noble
+  - jammy, noble, resolute
 - Debian
   - trixie, bookworm, bullseye
 - Alpine

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - "10"
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
     - name: Debian
@@ -28,7 +27,6 @@ galaxy_info:
     - name: SmartOS
     - name: FreeBSD
       versions:
-        - "13.2"
         - "14.0"
     - name: OpenBSD
       versions:

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - jammy
         - noble
+        - resolute
     - name: Debian
       versions:
         - trixie


### PR DESCRIPTION
This pull request updates platform support and test configurations across multiple hardening roles, particularly focusing on updating supported distributions, cleaning up dependencies, and improving test reliability. The main themes are: updating OS matrix to newer versions, removing deprecated or unsupported platforms, aligning documentation, and simplifying Ansible collection usage.

**Platform and Test Matrix Updates:**

* Updated the supported OS versions in all relevant GitHub Actions workflows to include newer Fedora (42/43/44) and Ubuntu (22.04/24.04/26.04) releases, while removing older versions (Fedora 39/40, Ubuntu 20.04) from the test matrix for `os_hardening`, `ssh_hardening`, `nginx_hardening`, and `mysql_hardening` workflows. [[1]](diffhunk://#diff-85ef2c9a53cc9fbfd428fcdc3d140e0c087cab42f7ace23b0bf580305e110616L49-R54) [[2]](diffhunk://#diff-0b8cb6a926dcb7d47eec6270fd97f49dbada70bac2d1a664aed9d6f019d50ebaL52-R57) [[3]](diffhunk://#diff-fd5841ba27f48b20129f0568a9bb71f4fd5fe73c1907c2b5512696bd7f363918L52-R57) [[4]](diffhunk://#diff-e6e459ded859c24cf81d9fa2f3a2b12aa20ef16c22550ab47aca63e8da1409acL47-R49) [[5]](diffhunk://#diff-c041b49dac12c038976589c2d45da954340af0083bd9e5fabe30a832191d38a9L46-R48)
* Updated VM test images to match the new OS support, including new images for Debian 13 and Ubuntu 26.04, and removing or commenting out images that lack compatible test images. [[1]](diffhunk://#diff-8a1040c0d7f1a4863badfc7265975f4a18b1a2f2acc9244e1c24987e84936810L47-R54) [[2]](diffhunk://#diff-6c12040b35f5ba0f00b8dcc04a01f131b205547f929ae78fd33ef69a0073e1dcL42-R45)

**Documentation Alignment:**

* Updated the `README.md` to reflect the new list of supported distributions, removing references to outdated Fedora and Ubuntu versions and adding the newly supported ones.

**Ansible Collection and Role Simplification:**

* Switched from using the `community.mysql.mysql_query` module to `ansible.mysql.mysql_query` in all MySQL-related test tasks, and removed the explicit dependency on the `community.mysql` collection from `requirements.yml`. [[1]](diffhunk://#diff-89b87ecb99e34d1b3b6bd1ee4c54c30aa1b3174b785c1c9b67c89738d2cf3d35L3-R3) [[2]](diffhunk://#diff-89b87ecb99e34d1b3b6bd1ee4c54c30aa1b3174b785c1c9b67c89738d2cf3d35L18-R18) [[3]](diffhunk://#diff-89b87ecb99e34d1b3b6bd1ee4c54c30aa1b3174b785c1c9b67c89738d2cf3d35L27-R27) [[4]](diffhunk://#diff-c93cb3fa3584cf1190676bb69056739560121c4cf5e5fd3ace1d152f2c876552L3-R3) [[5]](diffhunk://#diff-c93cb3fa3584cf1190676bb69056739560121c4cf5e5fd3ace1d152f2c876552L28-R28) [[6]](diffhunk://#diff-c971b347b94038acf5fde58f9b6246f7d50b33b0aa838516647f32bc8b23b0fbL5-L9)
* Removed obsolete logic for determining MySQL Python libraries for older Ubuntu/Debian releases in test playbooks, simplifying the setup. [[1]](diffhunk://#diff-17578d856abbdbd2ea643920f774db4d02734e349d3470b803644e96096b2ec4L18-L25) [[2]](diffhunk://#diff-98109138562c5f82141baf8268ad2c7a0bc1fa90251b4c3ddadf96fb5372ab92L54-L61)

**Test and Verification Improvements:**

* Added explicit `password_expire_max: "-1"` to user creation tasks in password aging tests to ensure consistent behavior across platforms.
* Adjusted assertions for Suse SSH authentication tests to check for the correct error message about password expiration.
* Added overrides for Debian 13 image in VM tests to ensure correct `/tmp` mounting behavior.
* Improved Arch Linux VM preparation by updating the keyring and OS before installing Python.

**Waiver and Exclusion Updates:**

* Updated waiver files for AlmaLinux 10 and Debian 13 to include a dummy waived control, as required by `cinc-auditor`.
* Removed a specific waiver for FreeBSD 13, possibly indicating the issue is resolved or no longer relevant.