### PR TITLE
Update pam_rhel.yml

### DIFF
--- a/roles/os_hardening/tasks/pam_rhel.yml
+++ b/roles/os_hardening/tasks/pam_rhel.yml
@@ -10,7 +10,7 @@
   ansible.builtin.template:
     src: etc/pam.d/rhel_auth.j2
     dest: /etc/pam.d/system-auth-local
-    mode: "0640"
+    mode: "0644"
     owner: root
     group: root
 
@@ -18,7 +18,7 @@
   ansible.builtin.file:
     src: /etc/pam.d/system-auth-local
     dest: /etc/pam.d/system-auth
-    mode: "0640"
+    mode: "0644"
     owner: root
     group: root
     state: link
@@ -28,7 +28,7 @@
   ansible.builtin.template:
     src: etc/pam.d/rhel_auth.j2
     dest: /etc/pam.d/password-auth-local
-    mode: "0640"
+    mode: "0644"
     owner: root
     group: root
 
@@ -36,7 +36,7 @@
   ansible.builtin.file:
     src: /etc/pam.d/password-auth-local
     dest: /etc/pam.d/password-auth
-    mode: "0640"
+    mode: "0644"
     owner: root
     group: root
     state: link


### PR DESCRIPTION
This fixes #922.

The current RHEL PAM tasks create `system-auth-local` and `password-auth-local` as `root:root` with mode `0640`. that makes the files readable only by root, since there is no standard `pam` group that unprivileged PAM consumers belong to. That breaks applications such as `swaylock` and `xscreensaver`, which call into PAM as the logged-in user and need to read the relevant service configuration.

I checked the likely benchmark lineage for this setup. The RHEL 7 STIG guidance explains the use of `system-auth-local` and `password-auth-local` to prevent `authconfig` from overwriting hardened PAM configuration, but I could not find a requirement that these files be unreadable by ordinary users. Current ComplianceAsCode-generated RHEL 9 content also uses `0644` for `/etc/pam.d/password-auth`.

PAM configuration files generally do not contain secrets. Their integrity matters, but that remains protected by `root:root` ownership and the absence of group or world write permissions. If a PAM module requires a secret, that secret should live in a separate root-only file rather than relying on the entire PAM policy being unreadable.