### PR TITLE
Fix: skip os-09 rhosts cleanup for non-directory homes

### DIFF
--- a/roles/os_hardening/tasks/rhosts.yml
+++ b/roles/os_hardening/tasks/rhosts.yml
@@ -1,15 +1,27 @@
 ---
-- name: Get user accounts | os-09
-  ansible.builtin.command: "awk -F: '{print $1}' /etc/passwd"
+- name: Get user home directories | os-09
+  ansible.builtin.command: "awk -F: '{print $6}' /etc/passwd"
   changed_when: false
   check_mode: false
-  register: users_accounts
+  register: users_home_dirs
+
+- name: Stat user home directories | os-09
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ users_home_dirs.stdout_lines | flatten | unique | default([]) }}"
+  register: users_home_dir_stats
+  changed_when: false
+  check_mode: false
+  loop_control:
+    label: "{{ item }}"
 
 - name: Delete rhosts-files from system | os-09
   ansible.builtin.file:
-    dest: ~{{ item }}/.rhosts
+    dest: "{{ item.stat.path }}/.rhosts"
     state: absent
-  loop: "{{ users_accounts.stdout_lines | flatten | default([]) }}"
+  loop: "{{ users_home_dir_stats.results | selectattr('stat.isdir', 'defined') | selectattr('stat.isdir') | list }}"
+  loop_control:
+    label: "{{ item.stat.path }}"
 
 - name: Delete hosts.equiv from system | os-01
   ansible.builtin.file:


### PR DESCRIPTION
The "Delete rhosts-files from system" task fails on any host that has a user account whose home directory is not a real directory (for example `/dev/null`), which is a possible for service/daemon accounts.


---

My setup:

```
ansible==14.2.0
ansible-core==2.21
```

This was working fine previously, but has been failing since I upgraded to `ansible-core==2.21`. I suspect some underlying change in Ansible has surfaced this. 

Depending on how we want to look at this, it could be considered a bug in Ansible or a bug in the role. A good possibility could be this change: https://github.com/ansible/ansible/pull/86608/changes#diff-fac18227ce0859d592f910f73aff6e6c840b31ba5821ba1a88c6a16129a1d4f9L313
 
---

Context: 


On a Rocky Linux host with the `valkey` package installed, the package creates its service account with `/dev/null` as home:
```
  $ getent passwd valkey
  valkey:x:990:987:Valkey Database Server:/dev/null:/sbin/nologin

  $ rpm -q --scripts valkey | grep useradd
  useradd -r -g 'valkey' -d '/dev/null' -s '/sbin/nologin' -c 'Valkey Database Server' 'valkey' || :
```

The role then fails:

```
  TASK [devsec.hardening.os_hardening : Delete rhosts-files from system | os-09]
  failed: [host] (item=valkey) => {"changed": false, "item": "valkey",
    "msg": "Task failed: Module failed: [Errno 20] Not a directory: b'/dev/null/.rhosts'"}
```

---

Right now:

The task loops over every `/etc/passwd` account and builds `~<user>/.rhosts`. 
  
`~valkey` expands to `/dev/null`, so the file module tries to operate on `/dev/null/.rhosts`. Since `/dev/null` is not a folder, this fails with `(errno 20)`. 

---

The fix:

Read the home directory field from `/etc/passwd` directly instead of relying on `~user` tilde expansion, and only attempt `.rhosts` removal on homes that are actual directories. 

This might also has the benefit of working correctly on cases in which the username is not the same as the home directory name (for example, if the home directory is `/home/foobar` but the username is `barbaz`).