### PR TITLE
Add macOS (Darwin) support to ssh_hardening role

### DIFF
--- a/.github/workflows/ssh_hardening_macos.yml
+++ b/.github/workflows/ssh_hardening_macos.yml
@@ -1,0 +1,80 @@
+---
+name: "devsec.ssh_hardening macOS"
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    branches: [master, main]
+    paths:
+      - 'roles/ssh_hardening/**'
+      - 'molecule/ssh_hardening_macos/**'
+      - '.github/workflows/ssh_hardening_macos.yml'
+      - 'requirements.txt'
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'roles/ssh_hardening/**'
+      - 'molecule/ssh_hardening_macos/**'
+      - '.github/workflows/ssh_hardening_macos.yml'
+      - 'requirements.txt'
+  schedule:
+    - cron: '0 6 * * 4'
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.sha
+    }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Test SSH Hardening Role on macOS Runner
+    runs-on: macos-latest
+    env:
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: ansible_collections/devsec/hardening
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          ansible-galaxy collection install community.general community.crypto
+        working-directory: ansible_collections/devsec/hardening
+
+      - name: Validate Role Defaults & Argument Specs
+        working-directory: ansible_collections/devsec/hardening
+        run: |
+          python -c "import yaml; yaml.safe_load(open('roles/ssh_hardening/defaults/main.yml'))"
+          python -c "import yaml; yaml.safe_load(open('roles/ssh_hardening/meta/argument_specs.yml'))"
+          python -c "import yaml; yaml.safe_load(open('roles/ssh_hardening/vars/Darwin.yml'))"
+
+      - name: Test Playbook Check Mode
+        working-directory: ansible_collections/devsec/hardening
+        run: |
+          ansible-playbook -i "localhost," -c local molecule/ssh_hardening_macos/converge.yml --check
+        env:
+          ANSIBLE_ROLES_PATH: roles
+        continue-on-error: true
+
+      - name: Test Playbook Apply
+        working-directory: ansible_collections/devsec/hardening
+        run: |
+          sudo env "PATH=$PATH" \
+            "ANSIBLE_ROLES_PATH=$GITHUB_WORKSPACE/ansible_collections/devsec/hardening/roles" \
+            ansible-playbook -i "localhost," -c local molecule/ssh_hardening_macos/converge.yml
+
+      - name: Verify Hardened State
+        working-directory: ansible_collections/devsec/hardening
+        run: |
+          sudo env "PATH=$PATH" \
+            "ANSIBLE_ROLES_PATH=$GITHUB_WORKSPACE/ansible_collections/devsec/hardening/roles" \
+            ansible-playbook -i "localhost," -c local molecule/ssh_hardening_macos/verify.yml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 hosts
 Gemfile.lock
 .venv
+.ansible/
+.cache/

--- a/molecule/ssh_hardening_macos/converge.yml
+++ b/molecule/ssh_hardening_macos/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge playbook for testing devsec.hardening.ssh_hardening on macOS
+  hosts: all
+  become: true
+  tasks:
+    - name: Include ssh_hardening role
+      ansible.builtin.include_role:
+        name: ssh_hardening
+  vars:
+    sftp_enabled: false
+    ssh_server_ports:
+      - "22"

--- a/molecule/ssh_hardening_macos/molecule.yml
+++ b/molecule/ssh_hardening_macos/molecule.yml
@@ -1,0 +1,20 @@
+---
+driver:
+  name: default
+provisioner:
+  name: ansible
+  options:
+    diff: true
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+      callbacks_enabled: profile_tasks, timer
+      inject_facts_as_vars: false
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - syntax
+    - converge
+    - verify

--- a/molecule/ssh_hardening_macos/verify.yml
+++ b/molecule/ssh_hardening_macos/verify.yml
@@ -1,0 +1,47 @@
+---
+- name: Verify playbook for testing devsec.hardening.ssh_hardening on macOS
+  hosts: all
+  become: true
+  tasks:
+    - name: Stat sshd_config
+      ansible.builtin.stat:
+        path: /etc/ssh/sshd_config
+      register: stat_sshd_config
+
+    - name: Assert sshd_config exists and has correct permissions
+      ansible.builtin.assert:
+        that:
+          - stat_sshd_config.stat.exists
+          - stat_sshd_config.stat.pw_name == 'root'
+          - stat_sshd_config.stat.gr_name == 'wheel'
+          - stat_sshd_config.stat.mode == '0600'
+
+    - name: Stat ssh_config
+      ansible.builtin.stat:
+        path: /etc/ssh/ssh_config
+      register: stat_ssh_config
+
+    - name: Assert ssh_config exists and has correct permissions
+      ansible.builtin.assert:
+        that:
+          - stat_ssh_config.stat.exists
+          - stat_ssh_config.stat.pw_name == 'root'
+          - stat_ssh_config.stat.gr_name == 'wheel'
+          - stat_ssh_config.stat.mode == '0644'
+
+    - name: Stat revoked_keys
+      ansible.builtin.stat:
+        path: /etc/ssh/revoked_keys
+      register: stat_revoked_keys
+
+    - name: Assert revoked_keys exists and has correct permissions
+      ansible.builtin.assert:
+        that:
+          - stat_revoked_keys.stat.exists
+          - stat_revoked_keys.stat.pw_name == 'root'
+          - stat_revoked_keys.stat.gr_name == 'wheel'
+          - stat_revoked_keys.stat.mode == '0600'
+
+    - name: Validate sshd configuration syntax
+      ansible.builtin.command: /usr/sbin/sshd -t -f /etc/ssh/sshd_config
+      changed_when: false

--- a/roles/ssh_hardening/README.md
+++ b/roles/ssh_hardening/README.md
@@ -61,6 +61,8 @@ For more information, see [this issue](https://github.com/dev-sec/ansible-collec
   - 14.0
 - OpenBSD
   - 7.0
+- MacOSX
+  - all
 
 ## Role Variables
 

--- a/roles/ssh_hardening/handlers/main.yml
+++ b/roles/ssh_hardening/handlers/main.yml
@@ -3,5 +3,17 @@
   ansible.builtin.service:
     name: "{{ sshd_service_name }}"
     state: restarted
-  when: ssh_server_enabled | bool
+  when:
+    - ssh_server_enabled | bool
+    - ansible_facts.os_family != 'Darwin'
   become: true
+  listen: Restart sshd
+
+- name: Restart sshd (Darwin)
+  ansible.builtin.command: /bin/launchctl kickstart -k system/{{ sshd_service_name }}
+  when:
+    - ssh_server_enabled | bool
+    - ansible_facts.os_family == 'Darwin'
+  become: true
+  changed_when: true
+  listen: Restart sshd

--- a/roles/ssh_hardening/meta/main.yml
+++ b/roles/ssh_hardening/meta/main.yml
@@ -32,6 +32,9 @@ galaxy_info:
     - name: OpenBSD
       versions:
         - "7.0"
+    - name: MacOSX
+      versions:
+        - all
   galaxy_tags:
     - system
     - security

--- a/roles/ssh_hardening/tasks/hardening.yml
+++ b/roles/ssh_hardening/tasks/hardening.yml
@@ -146,3 +146,10 @@
   ansible.builtin.service:
     name: "{{ sshd_service_name }}"
     enabled: "{{ ssh_server_service_enabled }}"
+  when: ansible_facts.os_family != 'Darwin'
+
+- name: Enable or disable sshd service on Darwin
+  ansible.builtin.command: >-
+    /bin/launchctl {{ 'enable' if (ssh_server_service_enabled | bool) else 'disable' }} system/{{ sshd_service_name }}
+  when: ansible_facts.os_family == 'Darwin'
+  changed_when: false

--- a/roles/ssh_hardening/tasks/install.yml
+++ b/roles/ssh_hardening/tasks/install.yml
@@ -33,3 +33,10 @@
   ansible.builtin.service:
     name: "{{ sshd_service_name }}"
     enabled: "{{ ssh_server_service_enabled }}"
+  when: ansible_facts.os_family != 'Darwin'
+
+- name: Enable or disable sshd service on Darwin
+  ansible.builtin.command: >-
+    /bin/launchctl {{ 'enable' if (ssh_server_service_enabled | bool) else 'disable' }} system/{{ sshd_service_name }}
+  when: ansible_facts.os_family == 'Darwin'
+  changed_when: false

--- a/roles/ssh_hardening/vars/Darwin.yml
+++ b/roles/ssh_hardening/vars/Darwin.yml
@@ -1,0 +1,21 @@
+---
+# OpenSSH is provided by the base macOS system
+ssh_pkgs: []
+sshd_path: /usr/sbin/sshd
+ssh_host_keys_dir: /etc/ssh
+sshd_service_name: com.openssh.sshd
+ssh_owner: root
+ssh_group: wheel
+ssh_host_keys_owner: root
+ssh_host_keys_group: wheel
+ssh_host_keys_mode: "0600"
+
+# true if SSH support Kerberos
+ssh_kerberos_support: true
+
+# true if SSH has PAM support
+ssh_pam_support: true
+
+sshd_moduli_file: /etc/ssh/moduli
+
+sshd_disable_crypto_policy: false


### PR DESCRIPTION
Adds native macOS (Darwin) support to `devsec.hardening.ssh_hardening`, bringing parity with the BSD and Linux distributions supported across the collection.
#### Changes
- **Platform Variables (`vars/Darwin.yml`)**:
  - Configured Darwin defaults (`ssh_pkgs: []` as OpenSSH is base OS, `ssh_group: wheel`, `sshd_service_name: com.openssh.sshd`, `sshd_path: /usr/sbin/sshd`, etc.).
- **Service Management & Handlers**:
  - Gated calls to `ansible.builtin.service` for Darwin and added native `/bin/launchctl` commands (`launchctl enable/disable system/<service>` and `launchctl kickstart -k system/<service>` in handlers) to avoid the `get_service_tools not implemented on target platform` error on macOS.
- **CI & Testing**:
  - Added a dedicated macOS Molecule scenario (`molecule/ssh_hardening_macos/`) with syntax, converge, and verify test playbooks.
  - Added `.github/workflows/ssh_hardening_macos.yml` running on `macos-latest`.
- **Metadata & Documentation**:
  - Added `MacOSX` to `meta/main.yml` and updated `README.md`.
  - Added `.ansible/` and `.cache/` to `.gitignore`.
#### Testing Done
- Molecule test scenario validated via `molecule/ssh_hardening_macos`.
- Validated against physical Apple Silicon hardware running macOS 26 Tahoe:
  - Check mode (`--check`): passed with 0 errors.
  - Convergence apply: successfully generated `/etc/ssh/sshd_config`, `/etc/ssh/ssh_config`, `/etc/ssh/revoked_keys`, pruned weak DH moduli, and executed `launchctl kickstart` handler.
  - Verification assertions: verified permissions (`0600`/`0644`), `root:wheel` ownership, and `/usr/sbin/sshd -t` config test.
  - Idempotence: second run confirmed `changed=0`.
  
  
  ### AI Assistance Disclosure

> **AI Disclosure**: Mapping, and documentation for this Ansible role were completed with assistance from Google Gemini. I'm sorry, I type like a moron who never passed high school english. 