### PR TITLE
Remove unused initramfs handler

### DIFF
--- a/roles/os_hardening/handlers/main.yml
+++ b/roles/os_hardening/handlers/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Update-initramfs # noqa no-changed-when
-  ansible.builtin.command: update-initramfs -u
-
 - name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true


### PR DESCRIPTION
## Description

Fixes #911

The task that notified the `Update-initramfs` handler was removed in #591, but the handler itself was left in `roles/os_hardening/handlers/main.yml`, making it unreachable dead code.

## Cause

PR #591 dropped the `update-initramfs` task without removing its handler, so `roles/os_hardening/handlers/main.yml` kept a handler that nothing can notify anymore.

## Changes

- Remove the unreachable `Update-initramfs` handler from `roles/os_hardening/handlers/main.yml` (3 lines, no functional change).

## Verification

- Base SHA: `3102edd` (current `master` at the time of the change; still the tip of `master`).
- `grep -rn "initramfs" roles/` confirms no remaining task, handler or template references (only historical CHANGELOG entries).
- Checked that no other role or playbook notifies `Update-initramfs`.
- Full repo lint (molecule/galaxy) was not run locally because the sandbox cannot reach Ansible Galaxy; the change is a pure deletion of dead YAML with no module or argument changes.

## Risk

Minimal: deleting an unreachable handler cannot change runtime behavior. CI on this PR will run the collection's own lint and molecule checks.

## AI assistance disclosure

This patch was prepared by an autonomous AI coding agent at the direction of the account owner, following the repository's contributor guideline (fork, branch, minimal change, DCO sign-off).