### PR TITLE
Added loop_control.label to os-02 and os-03. 

### DIFF
--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -1,15 +1,26 @@
 ---
-# If the find-task throws an error on /usr/bin/X11 like "File system loop detected"
-# the other files inside /usr/bin (and all other directories) are
-# still getting found and the permissions minimized in the next task.
-# This is also the reason why there's ignore_errors: true on the task.
-# also see: https://github.com/dev-sec/ansible-os-hardening/issues/219
+# GNU find returns non-zero when -L encounters filesystem loops such as
+# /usr/bin/X11 -> ., while continuing to report other matching files.
+# Treat loop-only diagnostics as expected but preserve all other find failures.
+# See: https://github.com/dev-sec/ansible-collection-hardening/issues/215
+#      https://github.com/dev-sec/ansible-collection-hardening/issues/815
 - name: Find files with write-permissions for group # noqa command-instead-of-shell
   ansible.builtin.shell: find -L {{ item }} -perm /go+w -type f
   with_community.general.flattened:
     - "{{ os_env_user_paths }}"
     - "{{ os_env_extra_user_paths }}"
   register: minimize_access_directories
+  failed_when: >-
+    minimize_access_directories.rc != 0
+    and (
+      minimize_access_directories.stderr_lines | length == 0
+      or (
+        minimize_access_directories.stderr_lines
+        | reject('match', '^find: File system loop detected; ')
+        | list
+        | length > 0
+      )
+    )
   ignore_errors: true
   changed_when: false
 

--- a/roles/os_hardening/tasks/minimize_access.yml
+++ b/roles/os_hardening/tasks/minimize_access.yml
@@ -40,6 +40,8 @@
     mode: "{{ os_shadow_perms.mode }}"
   when: item.stat.exists
   loop: "{{ minimize_access_shadow_files.results }}"
+  loop_control:
+    label: "{{ item.item }}"
 
 - name: Find passwd files
   ansible.builtin.stat:
@@ -59,6 +61,8 @@
     mode: "{{ os_passwd_perms.mode }}"
   when: item.stat.exists
   loop: "{{ minimize_access_passwd_files.results }}"
+  loop_control:
+    label: "{{ item.item }}"
 
 - name: Change su-binary to only be accessible to user and group root
   ansible.builtin.file:


### PR DESCRIPTION

This PR makes three small changes to `roles/os_hardening/tasks/minimise_access.yml`:

I added loop_control.label using {{ item.item }} to os-02 (shadow) and os-03 (passwd) tasks to prevent dumping full stat dictionaries on iteration. This just makes the scrollback a bit more readable. 

I also changed the existing `find -L` task's failure handling for the long-standing `/usr/bin/X11 -> .` filesystem-loop condition reported in #215 and #815.

I initially considered changing the traversal mode to `-H` but after going through #215 and #815, I realized the historical reasons for choosing -H over -L. , but that would reduce the existing recursive symlink coverage. Instead, this keeps `find -L` unchanged and uses `failed_when` to distinguish the known GNU `find` loop diagnostic from other failures.

When `find` returns non-zero and its stderr contains only `File system loop detected` diagnostics, the task is treated as successful and the files already returned on stdout continue to be processed as before. If stderr contains any other error, the task retains its existing failed/ignored behavior.

This keeps the current hardening semantics while removing a known false-failure condition from normal Ansible output  -which was the point of this PR. I've spent waaaay too long looking at the scroll-back from this role on debian servers 😂

